### PR TITLE
feat(M1): two entry points, two live cameras, with Codex-review follow-ups

### DIFF
--- a/diagnostic.html
+++ b/diagnostic.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BalloonShoot 診断ワークベンチ</title>
+  </head>
+  <body>
+    <div id="diagnostic-app"></div>
+    <script type="module" src="/src/diagnostic-main.ts"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <p>2カメラ構成の PoC を構築中です。</p>
         <p>
           診断ワークベンチ:
-          <a href="/diagnostic.html">diagnostic.html</a>
+          <a href="./diagnostic.html">diagnostic.html</a>
         </p>
       </main>
     </div>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
       <main class="app-shell">
         <h1>BalloonShoot v2</h1>
         <p>2カメラ構成の PoC を構築中です。</p>
+        <p>
+          診断ワークベンチ:
+          <a href="/diagnostic.html">diagnostic.html</a>
+        </p>
       </main>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "vitest": "^4.1.3"
   },
   "knip": {
-    "entry": ["index.html"]
+    "entry": ["index.html", "diagnostic.html", "src/diagnostic-main.ts"]
   }
 }

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -1,0 +1,94 @@
+import "./styles/diagnostic.css";
+import {
+  createDiagnosticWorkbench,
+  type DiagnosticWorkbench
+} from "./features/diagnostic-workbench/DiagnosticWorkbench";
+import { renderWorkbenchHTML } from "./features/diagnostic-workbench/renderWorkbench";
+
+const root = document.querySelector<HTMLDivElement>("#diagnostic-app");
+
+if (!root) {
+  throw new Error("Missing #diagnostic-app root");
+}
+
+const workbench: DiagnosticWorkbench = createDiagnosticWorkbench();
+
+const render = (): void => {
+  const state = workbench.getState();
+  root.innerHTML = renderWorkbenchHTML(state);
+  attachVideoStreams(state);
+};
+
+const attachVideoStreams = (
+  state: ReturnType<DiagnosticWorkbench["getState"]>
+): void => {
+  if (state.screen !== "previewing") {
+    return;
+  }
+
+  const frontVideo = document.querySelector<HTMLVideoElement>("#wb-front-video");
+  const sideVideo = document.querySelector<HTMLVideoElement>("#wb-side-video");
+
+  if (frontVideo !== null && state.frontStream !== undefined) {
+    frontVideo.srcObject = state.frontStream.stream;
+  }
+
+  if (sideVideo !== null && state.sideStream !== undefined) {
+    sideVideo.srcObject = state.sideStream.stream;
+  }
+};
+
+const handleClick = (e: MouseEvent): void => {
+  const target = e.target;
+
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const actionEl = target.closest<HTMLElement>("[data-wb-action]");
+
+  if (actionEl === null) {
+    return;
+  }
+
+  const action = actionEl.dataset["wbAction"];
+
+  switch (action) {
+    case "requestPermission":
+      void workbench.requestPermission();
+      break;
+    case "confirmDevices": {
+      const frontSelect =
+        document.querySelector<HTMLSelectElement>("#wb-front-select");
+      const sideSelect =
+        document.querySelector<HTMLSelectElement>("#wb-side-select");
+
+      if (frontSelect === null || sideSelect === null) {
+        return;
+      }
+
+      const frontId = frontSelect.value;
+      const sideId = sideSelect.value;
+
+      if (frontId === sideId) {
+        alert("フロントとサイドには異なるカメラを選択してください。");
+        return;
+      }
+
+      void workbench.assignDevices(frontId, sideId);
+      break;
+    }
+    case "swap":
+      void workbench.swapRoles();
+      break;
+    case "reselect":
+      workbench.reselect();
+      break;
+  }
+};
+
+root.addEventListener("click", handleClick);
+workbench.subscribe(render);
+
+// Initial render
+render();

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -52,10 +52,15 @@ const handleClick = (e: MouseEvent): void => {
   }
 
   const action = actionEl.dataset["wbAction"];
+  const runAction = (actionPromise: Promise<void>): void => {
+    void actionPromise.catch((error: unknown) => {
+      console.error("Diagnostic workbench action failed", error);
+    });
+  };
 
   switch (action) {
     case "requestPermission":
-      void workbench.requestPermission();
+      runAction(workbench.requestPermission());
       break;
     case "confirmDevices": {
       const frontSelect =
@@ -75,11 +80,11 @@ const handleClick = (e: MouseEvent): void => {
         return;
       }
 
-      void workbench.assignDevices(frontId, sideId);
+      runAction(workbench.assignDevices(frontId, sideId));
       break;
     }
     case "swap":
-      void workbench.swapRoles();
+      runAction(workbench.swapRoles());
       break;
     case "reselect":
       workbench.reselect();

--- a/src/features/camera/cameraPermission.ts
+++ b/src/features/camera/cameraPermission.ts
@@ -1,17 +1,67 @@
+interface CameraPermissionError {
+  readonly name: string;
+  readonly message: string;
+}
+
+type CameraPermissionResult =
+  | { readonly status: "granted" }
+  | { readonly status: "unsupported"; readonly error: CameraPermissionError }
+  | { readonly status: "denied"; readonly error: CameraPermissionError }
+  | { readonly status: "notFound"; readonly error: CameraPermissionError }
+  | { readonly status: "failed"; readonly error: CameraPermissionError };
+
+interface RuntimeNavigator {
+  readonly mediaDevices?: Partial<MediaDevices>;
+}
+
+const toPermissionError = (error: unknown): CameraPermissionError => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message
+    };
+  }
+
+  return {
+    name: "UnknownError",
+    message: String(error)
+  };
+};
+
+const classifyPermissionFailure = (
+  error: unknown
+): Exclude<CameraPermissionResult, { readonly status: "granted" }> => {
+  const permissionError = toPermissionError(error);
+
+  switch (permissionError.name) {
+    case "NotAllowedError":
+    case "SecurityError":
+      return { status: "denied", error: permissionError };
+    case "NotFoundError":
+    case "DevicesNotFoundError":
+      return { status: "notFound", error: permissionError };
+    default:
+      return { status: "failed", error: permissionError };
+  }
+};
+
 /**
  * Request camera permission by opening a temporary stream.
  * After permission is granted the stream is stopped immediately;
  * actual capture streams are opened later with explicit deviceId constraints.
  */
-export const requestCameraPermission = async (): Promise<
-  "granted" | "denied"
-> => {
-  const mediaDevices = navigator.mediaDevices as
-    | MediaDevices
-    | undefined;
+export const requestCameraPermission = async (): Promise<CameraPermissionResult> => {
+  const mediaDevices = (globalThis as { readonly navigator?: RuntimeNavigator })
+    .navigator?.mediaDevices;
 
   if (mediaDevices === undefined || typeof mediaDevices.getUserMedia !== "function") {
-    return "denied";
+    return {
+      status: "unsupported",
+      error: {
+        name: "UnsupportedError",
+        message: "navigator.mediaDevices.getUserMedia is unavailable."
+      }
+    };
   }
 
   try {
@@ -24,8 +74,8 @@ export const requestCameraPermission = async (): Promise<
       t.stop();
     });
 
-    return "granted";
-  } catch {
-    return "denied";
+    return { status: "granted" };
+  } catch (error: unknown) {
+    return classifyPermissionFailure(error);
   }
 };

--- a/src/features/camera/cameraPermission.ts
+++ b/src/features/camera/cameraPermission.ts
@@ -1,0 +1,31 @@
+/**
+ * Request camera permission by opening a temporary stream.
+ * After permission is granted the stream is stopped immediately;
+ * actual capture streams are opened later with explicit deviceId constraints.
+ */
+export const requestCameraPermission = async (): Promise<
+  "granted" | "denied"
+> => {
+  const mediaDevices = navigator.mediaDevices as
+    | MediaDevices
+    | undefined;
+
+  if (mediaDevices === undefined || typeof mediaDevices.getUserMedia !== "function") {
+    return "denied";
+  }
+
+  try {
+    const tempStream = await mediaDevices.getUserMedia({
+      video: true,
+      audio: false
+    });
+
+    tempStream.getTracks().forEach((t) => {
+      t.stop();
+    });
+
+    return "granted";
+  } catch {
+    return "denied";
+  }
+};

--- a/src/features/camera/createDevicePinnedStream.ts
+++ b/src/features/camera/createDevicePinnedStream.ts
@@ -1,0 +1,35 @@
+import { gameConfig } from "../../shared/config/gameConfig";
+
+/**
+ * Open a camera stream pinned to an exact deviceId.
+ * The stream is tied to a generation counter so that stale requests
+ * can be detected and cancelled.
+ */
+export interface DevicePinnedStream {
+  readonly stream: MediaStream;
+  readonly deviceId: string;
+  stop(): void;
+}
+
+export const createDevicePinnedStream = async (
+  deviceId: string
+): Promise<DevicePinnedStream> => {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: {
+      deviceId: { exact: deviceId },
+      width: { ideal: gameConfig.camera.width },
+      height: { ideal: gameConfig.camera.height }
+    },
+    audio: false
+  });
+
+  return {
+    stream,
+    deviceId,
+    stop() {
+      stream.getTracks().forEach((t) => {
+        t.stop();
+      });
+    }
+  };
+};

--- a/src/features/camera/createDevicePinnedStream.ts
+++ b/src/features/camera/createDevicePinnedStream.ts
@@ -14,7 +14,17 @@ export interface DevicePinnedStream {
 export const createDevicePinnedStream = async (
   deviceId: string
 ): Promise<DevicePinnedStream> => {
-  const stream = await navigator.mediaDevices.getUserMedia({
+  const mediaDevices = (
+    globalThis as {
+      readonly navigator?: { readonly mediaDevices?: Partial<MediaDevices> };
+    }
+  ).navigator?.mediaDevices;
+
+  if (mediaDevices === undefined || typeof mediaDevices.getUserMedia !== "function") {
+    throw new Error("navigator.mediaDevices.getUserMedia is unavailable.");
+  }
+
+  const stream = await mediaDevices.getUserMedia({
     video: {
       deviceId: { exact: deviceId },
       width: { ideal: gameConfig.camera.width },

--- a/src/features/camera/createDevicePinnedStream.ts
+++ b/src/features/camera/createDevicePinnedStream.ts
@@ -2,8 +2,7 @@ import { gameConfig } from "../../shared/config/gameConfig";
 
 /**
  * Open a camera stream pinned to an exact deviceId.
- * The stream is tied to a generation counter so that stale requests
- * can be detected and cancelled.
+ * Callers own cancellation and stale-request handling around this helper.
  */
 export interface DevicePinnedStream {
   readonly stream: MediaStream;

--- a/src/features/camera/enumerateVideoDevices.ts
+++ b/src/features/camera/enumerateVideoDevices.ts
@@ -3,7 +3,20 @@
  * Must be called after camera permission is granted so labels are available.
  */
 export const enumerateVideoDevices = async (): Promise<MediaDeviceInfo[]> => {
-  const allDevices = await navigator.mediaDevices.enumerateDevices();
+  const mediaDevices = (
+    globalThis as {
+      readonly navigator?: { readonly mediaDevices?: Partial<MediaDevices> };
+    }
+  ).navigator?.mediaDevices;
+
+  if (
+    mediaDevices === undefined ||
+    typeof mediaDevices.enumerateDevices !== "function"
+  ) {
+    throw new Error("navigator.mediaDevices.enumerateDevices is unavailable.");
+  }
+
+  const allDevices = await mediaDevices.enumerateDevices();
 
   return allDevices.filter((d) => d.kind === "videoinput");
 };

--- a/src/features/camera/enumerateVideoDevices.ts
+++ b/src/features/camera/enumerateVideoDevices.ts
@@ -1,0 +1,9 @@
+/**
+ * Enumerate video input devices.
+ * Must be called after camera permission is granted so labels are available.
+ */
+export const enumerateVideoDevices = async (): Promise<MediaDeviceInfo[]> => {
+  const allDevices = await navigator.mediaDevices.enumerateDevices();
+
+  return allDevices.filter((d) => d.kind === "videoinput");
+};

--- a/src/features/diagnostic-workbench/AGENTS.md
+++ b/src/features/diagnostic-workbench/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## WHY
+
+- `src/features/diagnostic-workbench/` owns the diagnostic workbench UI reached through `diagnostic.html`.
+
+## WHAT
+
+- Camera device selection, role assignment, and live preview
+- Per-lane telemetry display and tuning controls
+- Landmark overlays, timestamp pairing monitor, trigger evidence panels
+
+## HOW
+
+- Observe lanes but do not own lane correctness.
+- Do not introduce workbench-only detection formats.
+- Do not import from `src/app/` or gameplay modules.
+- Lanes must not depend on this module.

--- a/src/features/diagnostic-workbench/CLAUDE.md
+++ b/src/features/diagnostic-workbench/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -90,6 +90,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
 
   const listeners = new Set<StateListener>();
   let openGeneration = 0;
+  let requestGeneration = 0;
 
   const emit = (): void => {
     for (const fn of listeners) {
@@ -338,9 +339,26 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     async requestPermission() {
-      update({ screen: "permission", error: undefined });
+      requestGeneration += 1;
+      openGeneration += 1;
+      const myGeneration = requestGeneration;
+
+      stopCurrentStreams();
+      update({
+        screen: "permission",
+        devices: [],
+        frontAssignment: undefined,
+        sideAssignment: undefined,
+        frontStream: undefined,
+        sideStream: undefined,
+        error: undefined
+      });
 
       const result = await requestCameraPermission();
+
+      if (myGeneration !== requestGeneration) {
+        return;
+      }
 
       if (result.status !== "granted") {
         const error = createError(permissionErrorKindFor(result.status));
@@ -354,8 +372,16 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       try {
         devices = await enumerateVideoDevices();
       } catch {
+        if (myGeneration !== requestGeneration) {
+          return;
+        }
+
         const error = createError("enumerationFailed");
         update({ screen: "enumerationFailed", error });
+        return;
+      }
+
+      if (myGeneration !== requestGeneration) {
         return;
       }
 
@@ -397,6 +423,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     reselect() {
+      requestGeneration += 1;
       openGeneration += 1;
       stopCurrentStreams();
       update({
@@ -410,6 +437,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     destroy() {
+      requestGeneration += 1;
       openGeneration += 1;
       stopCurrentStreams();
       listeners.clear();

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -1,0 +1,194 @@
+import type { CameraLaneRole } from "../../shared/types/camera";
+import { requestCameraPermission } from "../camera/cameraPermission";
+import { enumerateVideoDevices } from "../camera/enumerateVideoDevices";
+import {
+  createDevicePinnedStream,
+  type DevicePinnedStream
+} from "../camera/createDevicePinnedStream";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WorkbenchScreen =
+  | "permission"
+  | "permissionDenied"
+  | "deviceSelection"
+  | "singleCamera"
+  | "previewing";
+
+export interface DeviceAssignment {
+  role: CameraLaneRole;
+  deviceId: string;
+  label: string;
+}
+
+export interface WorkbenchState {
+  screen: WorkbenchScreen;
+  devices: MediaDeviceInfo[];
+  frontAssignment: DeviceAssignment | undefined;
+  sideAssignment: DeviceAssignment | undefined;
+  frontStream: DevicePinnedStream | undefined;
+  sideStream: DevicePinnedStream | undefined;
+}
+
+type StateListener = (state: WorkbenchState) => void;
+
+// ---------------------------------------------------------------------------
+// Workbench controller
+// ---------------------------------------------------------------------------
+
+export interface DiagnosticWorkbench {
+  getState(): WorkbenchState;
+  subscribe(listener: StateListener): () => void;
+  requestPermission(): Promise<void>;
+  assignDevices(
+    frontDeviceId: string,
+    sideDeviceId: string
+  ): Promise<void>;
+  swapRoles(): Promise<void>;
+  reselect(): void;
+  destroy(): void;
+}
+
+export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
+  let state: WorkbenchState = {
+    screen: "permission",
+    devices: [],
+    frontAssignment: undefined,
+    sideAssignment: undefined,
+    frontStream: undefined,
+    sideStream: undefined
+  };
+
+  const listeners = new Set<StateListener>();
+
+  const emit = (): void => {
+    for (const fn of listeners) {
+      fn(state);
+    }
+  };
+
+  const update = (patch: Partial<WorkbenchState>): void => {
+    state = { ...state, ...patch };
+    emit();
+  };
+
+  const stopStreams = (): void => {
+    state.frontStream?.stop();
+    state.sideStream?.stop();
+  };
+
+  const labelFor = (
+    devices: MediaDeviceInfo[],
+    deviceId: string
+  ): string => {
+    const found = devices.find((d) => d.deviceId === deviceId);
+    return found?.label !== undefined && found.label !== ""
+      ? found.label
+      : `Camera (${deviceId.slice(0, 8)})`;
+  };
+
+  const openStreams = async (
+    frontId: string,
+    sideId: string
+  ): Promise<void> => {
+    stopStreams();
+
+    const [frontStream, sideStream] = await Promise.all([
+      createDevicePinnedStream(frontId),
+      createDevicePinnedStream(sideId)
+    ]);
+
+    const frontLabel = labelFor(state.devices, frontId);
+    const sideLabel = labelFor(state.devices, sideId);
+
+    update({
+      screen: "previewing",
+      frontAssignment: {
+        role: "frontAim",
+        deviceId: frontId,
+        label: frontLabel
+      },
+      sideAssignment: {
+        role: "sideTrigger",
+        deviceId: sideId,
+        label: sideLabel
+      },
+      frontStream,
+      sideStream
+    });
+  };
+
+  return {
+    getState() {
+      return state;
+    },
+
+    subscribe(listener: StateListener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async requestPermission() {
+      update({ screen: "permission" });
+
+      const result = await requestCameraPermission();
+
+      if (result === "denied") {
+        update({ screen: "permissionDenied" });
+        return;
+      }
+
+      const devices = await enumerateVideoDevices();
+
+      if (devices.length < 2) {
+        update({ screen: "singleCamera", devices });
+        return;
+      }
+
+      update({ screen: "deviceSelection", devices });
+    },
+
+    async assignDevices(frontDeviceId: string, sideDeviceId: string) {
+      if (frontDeviceId === sideDeviceId) {
+        throw new Error(
+          "Front and side must be assigned to distinct devices"
+        );
+      }
+
+      await openStreams(frontDeviceId, sideDeviceId);
+    },
+
+    async swapRoles() {
+      const { frontAssignment, sideAssignment } = state;
+
+      if (frontAssignment === undefined || sideAssignment === undefined) {
+        return;
+      }
+
+      await openStreams(
+        sideAssignment.deviceId,
+        frontAssignment.deviceId
+      );
+    },
+
+    reselect() {
+      stopStreams();
+      update({
+        screen: "deviceSelection",
+        frontAssignment: undefined,
+        sideAssignment: undefined,
+        frontStream: undefined,
+        sideStream: undefined
+      });
+    },
+
+    destroy() {
+      stopStreams();
+      listeners.clear();
+    }
+  };
+};

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -62,6 +62,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   };
 
   const listeners = new Set<StateListener>();
+  let openGeneration = 0;
 
   const emit = (): void => {
     for (const fn of listeners) {
@@ -95,10 +96,19 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   ): Promise<void> => {
     stopStreams();
 
+    openGeneration += 1;
+    const myGeneration = openGeneration;
+
     const [frontStream, sideStream] = await Promise.all([
       createDevicePinnedStream(frontId),
       createDevicePinnedStream(sideId)
     ]);
+
+    if (myGeneration !== openGeneration) {
+      frontStream.stop();
+      sideStream.stop();
+      return;
+    }
 
     const frontLabel = labelFor(state.devices, frontId);
     const sideLabel = labelFor(state.devices, sideId);

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -12,10 +12,33 @@ import {
 
 export type WorkbenchScreen =
   | "permission"
+  | "cameraUnsupported"
   | "permissionDenied"
+  | "cameraNotFound"
+  | "enumerationFailed"
   | "deviceSelection"
   | "singleCamera"
+  | "cameraConstraintFailed"
+  | "cameraOpenFailed"
   | "previewing";
+
+export type WorkbenchErrorKind =
+  | "cameraUnsupported"
+  | "permissionDenied"
+  | "cameraNotFound"
+  | "enumerationFailed"
+  | "cameraConstraintFailed"
+  | "cameraOpenFailed"
+  | "distinctDevicesRequired";
+
+export interface WorkbenchError {
+  readonly kind: WorkbenchErrorKind;
+  readonly title: string;
+  readonly cause: string;
+  readonly impact: string;
+  readonly reproduction: string;
+  readonly nextAction: string;
+}
 
 export interface DeviceAssignment {
   role: CameraLaneRole;
@@ -30,6 +53,7 @@ export interface WorkbenchState {
   sideAssignment: DeviceAssignment | undefined;
   frontStream: DevicePinnedStream | undefined;
   sideStream: DevicePinnedStream | undefined;
+  error: WorkbenchError | undefined;
 }
 
 type StateListener = (state: WorkbenchState) => void;
@@ -58,7 +82,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     frontAssignment: undefined,
     sideAssignment: undefined,
     frontStream: undefined,
-    sideStream: undefined
+    sideStream: undefined,
+    error: undefined
   };
 
   const listeners = new Set<StateListener>();
@@ -75,59 +100,199 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     emit();
   };
 
-  const stopStreams = (): void => {
-    state.frontStream?.stop();
-    state.sideStream?.stop();
+  const stopStreams = (
+    ...streams: (DevicePinnedStream | undefined)[]
+  ): void => {
+    for (const stream of streams) {
+      stream?.stop();
+    }
+  };
+
+  const stopCurrentStreams = (): void => {
+    stopStreams(state.frontStream, state.sideStream);
   };
 
   const labelFor = (
     devices: MediaDeviceInfo[],
     deviceId: string
   ): string => {
-    const found = devices.find((d) => d.deviceId === deviceId);
-    return found?.label !== undefined && found.label !== ""
-      ? found.label
-      : `Camera (${deviceId.slice(0, 8)})`;
+    const foundIndex = devices.findIndex((d) => d.deviceId === deviceId);
+    const found = foundIndex >= 0 ? devices[foundIndex] : undefined;
+
+    if (found !== undefined && found.label !== "") {
+      return found.label;
+    }
+
+    return foundIndex >= 0 ? `Camera ${String(foundIndex + 1)}` : "Camera";
+  };
+
+  const createError = (kind: WorkbenchErrorKind): WorkbenchError => {
+    switch (kind) {
+      case "cameraUnsupported":
+        return {
+          kind,
+          title: "このブラウザではカメラを使用できません",
+          cause: "navigator.mediaDevices.getUserMedia が利用できません。",
+          impact: "フロント・サイド両方のキャプチャが開始できません。",
+          reproduction: "カメラ API 非対応のブラウザまたは非 HTTPS 相当の環境で診断ワークベンチを開いてください。",
+          nextAction: "Chrome の安全なローカル開発 URL で開き直してください。"
+        };
+      case "permissionDenied":
+        return {
+          kind,
+          title: "カメラ許可が拒否されました",
+          cause: "ブラウザのカメラ権限が拒否されました。",
+          impact: "フロント・サイド両方のキャプチャが開始できません。",
+          reproduction: "リロードしてカメラ権限を拒否してください。",
+          nextAction: "ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。"
+        };
+      case "cameraNotFound":
+        return {
+          kind,
+          title: "カメラが見つかりません",
+          cause: "ブラウザが video input device を検出できませんでした。",
+          impact: "フロント・サイド両方のキャプチャが開始できません。",
+          reproduction: "カメラを接続せずに診断ワークベンチを開いてください。",
+          nextAction: "カメラ接続と OS のカメラ権限を確認してからリトライしてください。"
+        };
+      case "enumerationFailed":
+        return {
+          kind,
+          title: "カメラ一覧を取得できません",
+          cause: "navigator.mediaDevices.enumerateDevices が失敗しました。",
+          impact: "フロント・サイドの割り当て画面を表示できません。",
+          reproduction: "カメラ許可後にデバイス列挙が失敗するブラウザ状態でリトライしてください。",
+          nextAction: "ブラウザのカメラ権限と接続状態を確認し、ページをリロードしてください。"
+        };
+      case "cameraConstraintFailed":
+        return {
+          kind,
+          title: "選択したカメラを現在の条件で開始できません",
+          cause: "選択した capture constraints がデバイスでサポートされていません。",
+          impact: "該当 lane の capture を開始できません。",
+          reproduction: "現在の設定で同じカメラを選択してください。",
+          nextAction: "別のカメラを再選択するか、PoC の既定条件でリトライしてください。"
+        };
+      case "cameraOpenFailed":
+        return {
+          kind,
+          title: "カメラを開始できません",
+          cause: "getUserMedia がカメラ開始中に失敗しました。",
+          impact: "選択した2台の live preview を開始できません。",
+          reproduction: "同じカメラ割り当てで確定を押してください。",
+          nextAction: "カメラが他のアプリで使用中でないか確認し、再選択してください。"
+        };
+      case "distinctDevicesRequired":
+        return {
+          kind,
+          title: "別々のカメラを選択してください",
+          cause: "フロントとサイドに同じ deviceId が選択されました。",
+          impact: "v2 の side trigger 設計を検証できません。",
+          reproduction: "フロントとサイドで同じカメラを選び、確定してください。",
+          nextAction: "フロントとサイドに異なるカメラを選択してください。"
+        };
+    }
+  };
+
+  const classifyOpenError = (error: unknown): WorkbenchError => {
+    if (error instanceof Error && error.name === "OverconstrainedError") {
+      return createError("cameraConstraintFailed");
+    }
+
+    return createError("cameraOpenFailed");
+  };
+
+  const errorScreenFor = (error: WorkbenchError): WorkbenchScreen => {
+    switch (error.kind) {
+      case "cameraUnsupported":
+      case "permissionDenied":
+      case "cameraNotFound":
+      case "enumerationFailed":
+      case "cameraConstraintFailed":
+      case "cameraOpenFailed":
+        return error.kind;
+      case "distinctDevicesRequired":
+        return state.screen;
+    }
   };
 
   const openStreams = async (
     frontId: string,
-    sideId: string
+    sideId: string,
+    preservePreviewOnFailure: boolean
   ): Promise<void> => {
-    stopStreams();
-
     openGeneration += 1;
     const myGeneration = openGeneration;
+    const previousFrontStream = state.frontStream;
+    const previousSideStream = state.sideStream;
+    const openedStreams: DevicePinnedStream[] = [];
 
-    const [frontStream, sideStream] = await Promise.all([
-      createDevicePinnedStream(frontId),
-      createDevicePinnedStream(sideId)
-    ]);
+    try {
+      const frontStream = await createDevicePinnedStream(frontId);
+      openedStreams.push(frontStream);
 
-    if (myGeneration !== openGeneration) {
-      frontStream.stop();
-      sideStream.stop();
-      return;
+      if (myGeneration !== openGeneration) {
+        stopStreams(...openedStreams);
+        return;
+      }
+
+      const sideStream = await createDevicePinnedStream(sideId);
+      openedStreams.push(sideStream);
+
+      if (myGeneration !== openGeneration) {
+        stopStreams(...openedStreams);
+        return;
+      }
+
+      const frontLabel = labelFor(state.devices, frontId);
+      const sideLabel = labelFor(state.devices, sideId);
+
+      stopStreams(previousFrontStream, previousSideStream);
+
+      update({
+        screen: "previewing",
+        frontAssignment: {
+          role: "frontAim",
+          deviceId: frontId,
+          label: frontLabel
+        },
+        sideAssignment: {
+          role: "sideTrigger",
+          deviceId: sideId,
+          label: sideLabel
+        },
+        frontStream,
+        sideStream,
+        error: undefined
+      });
+    } catch (error: unknown) {
+      stopStreams(...openedStreams);
+
+      if (myGeneration !== openGeneration) {
+        return;
+      }
+
+      const workbenchError = classifyOpenError(error);
+
+      if (
+        preservePreviewOnFailure &&
+        state.screen === "previewing" &&
+        state.frontStream !== undefined &&
+        state.sideStream !== undefined
+      ) {
+        update({ error: workbenchError });
+        return;
+      }
+
+      update({
+        screen: errorScreenFor(workbenchError),
+        frontAssignment: undefined,
+        sideAssignment: undefined,
+        frontStream: undefined,
+        sideStream: undefined,
+        error: workbenchError
+      });
     }
-
-    const frontLabel = labelFor(state.devices, frontId);
-    const sideLabel = labelFor(state.devices, sideId);
-
-    update({
-      screen: "previewing",
-      frontAssignment: {
-        role: "frontAim",
-        deviceId: frontId,
-        label: frontLabel
-      },
-      sideAssignment: {
-        role: "sideTrigger",
-        deviceId: sideId,
-        label: sideLabel
-      },
-      frontStream,
-      sideStream
-    });
   };
 
   return {
@@ -143,33 +308,49 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     async requestPermission() {
-      update({ screen: "permission" });
+      update({ screen: "permission", error: undefined });
 
       const result = await requestCameraPermission();
 
-      if (result === "denied") {
-        update({ screen: "permissionDenied" });
+      if (result.status !== "granted") {
+        const error =
+          result.status === "unsupported"
+            ? createError("cameraUnsupported")
+            : result.status === "denied"
+              ? createError("permissionDenied")
+              : result.status === "notFound"
+                ? createError("cameraNotFound")
+                : createError("cameraOpenFailed");
+
+        update({ screen: errorScreenFor(error), error });
         return;
       }
 
-      const devices = await enumerateVideoDevices();
+      let devices: MediaDeviceInfo[];
+
+      try {
+        devices = await enumerateVideoDevices();
+      } catch {
+        const error = createError("enumerationFailed");
+        update({ screen: "enumerationFailed", error });
+        return;
+      }
 
       if (devices.length < 2) {
-        update({ screen: "singleCamera", devices });
+        update({ screen: "singleCamera", devices, error: undefined });
         return;
       }
 
-      update({ screen: "deviceSelection", devices });
+      update({ screen: "deviceSelection", devices, error: undefined });
     },
 
     async assignDevices(frontDeviceId: string, sideDeviceId: string) {
       if (frontDeviceId === sideDeviceId) {
-        throw new Error(
-          "Front and side must be assigned to distinct devices"
-        );
+        update({ error: createError("distinctDevicesRequired") });
+        return;
       }
 
-      await openStreams(frontDeviceId, sideDeviceId);
+      await openStreams(frontDeviceId, sideDeviceId, state.screen === "previewing");
     },
 
     async swapRoles() {
@@ -181,23 +362,27 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
 
       await openStreams(
         sideAssignment.deviceId,
-        frontAssignment.deviceId
+        frontAssignment.deviceId,
+        true
       );
     },
 
     reselect() {
-      stopStreams();
+      openGeneration += 1;
+      stopCurrentStreams();
       update({
         screen: "deviceSelection",
         frontAssignment: undefined,
         sideAssignment: undefined,
         frontStream: undefined,
-        sideStream: undefined
+        sideStream: undefined,
+        error: undefined
       });
     },
 
     destroy() {
-      stopStreams();
+      openGeneration += 1;
+      stopCurrentStreams();
       listeners.clear();
     }
   };

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -14,6 +14,7 @@ export type WorkbenchScreen =
   | "permission"
   | "cameraUnsupported"
   | "permissionDenied"
+  | "permissionFailed"
   | "cameraNotFound"
   | "enumerationFailed"
   | "deviceSelection"
@@ -25,6 +26,7 @@ export type WorkbenchScreen =
 export type WorkbenchErrorKind =
   | "cameraUnsupported"
   | "permissionDenied"
+  | "permissionFailed"
   | "cameraNotFound"
   | "enumerationFailed"
   | "cameraConstraintFailed"
@@ -146,6 +148,15 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           reproduction: "リロードしてカメラ権限を拒否してください。",
           nextAction: "ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。"
         };
+      case "permissionFailed":
+        return {
+          kind,
+          title: "カメラ許可を確認できません",
+          cause: "許可確認用の getUserMedia が失敗しました。",
+          impact: "カメラ許可が完了せず、フロント・サイド両方のキャプチャ準備に進めません。",
+          reproduction: "カメラ許可操作後にブラウザまたは OS がカメラ開始を中断する状態でリトライしてください。",
+          nextAction: "カメラ接続、OS のカメラ権限、他アプリの使用状況を確認してからリトライしてください。"
+        };
       case "cameraNotFound":
         return {
           kind,
@@ -206,6 +217,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     switch (error.kind) {
       case "cameraUnsupported":
       case "permissionDenied":
+      case "permissionFailed":
       case "cameraNotFound":
       case "enumerationFailed":
       case "cameraConstraintFailed":
@@ -213,6 +225,24 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return error.kind;
       case "distinctDevicesRequired":
         return state.screen;
+    }
+  };
+
+  const permissionErrorKindFor = (
+    status: Exclude<
+      Awaited<ReturnType<typeof requestCameraPermission>>["status"],
+      "granted"
+    >
+  ): WorkbenchErrorKind => {
+    switch (status) {
+      case "unsupported":
+        return "cameraUnsupported";
+      case "denied":
+        return "permissionDenied";
+      case "notFound":
+        return "cameraNotFound";
+      case "failed":
+        return "permissionFailed";
     }
   };
 
@@ -313,14 +343,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       const result = await requestCameraPermission();
 
       if (result.status !== "granted") {
-        const error =
-          result.status === "unsupported"
-            ? createError("cameraUnsupported")
-            : result.status === "denied"
-              ? createError("permissionDenied")
-              : result.status === "notFound"
-                ? createError("cameraNotFound")
-                : createError("cameraOpenFailed");
+        const error = createError(permissionErrorKindFor(result.status));
 
         update({ screen: errorScreenFor(error), error });
         return;
@@ -336,7 +359,13 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
-      if (devices.length < 2) {
+      if (devices.length === 0) {
+        const error = createError("cameraNotFound");
+        update({ screen: "cameraNotFound", devices, error });
+        return;
+      }
+
+      if (devices.length === 1) {
         update({ screen: "singleCamera", devices, error: undefined });
         return;
       }

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -1,0 +1,99 @@
+import type { WorkbenchState } from "./DiagnosticWorkbench";
+
+const renderPermissionScreen = (): string => `
+  <div class="wb-screen">
+    <h2>診断ワークベンチ</h2>
+    <p>フロントカメラ（照準）とサイドカメラ（トリガー）の2台を使います。</p>
+    <button class="wb-btn" data-wb-action="requestPermission">カメラ許可</button>
+  </div>
+`;
+
+const renderPermissionDenied = (): string => `
+  <div class="wb-screen wb-error">
+    <h2>カメラ許可が拒否されました</h2>
+    <p><strong>原因:</strong> ブラウザのカメラ権限が拒否されました。</p>
+    <p><strong>影響:</strong> フロント・サイド両方のキャプチャが開始できません。</p>
+    <p><strong>再現:</strong> リロードしてカメラ権限を拒否してください。</p>
+    <p><strong>対処:</strong> ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。</p>
+    <button class="wb-btn" data-wb-action="requestPermission">リトライ</button>
+  </div>
+`;
+
+const renderSingleCamera = (): string => `
+  <div class="wb-screen wb-warning">
+    <h2>カメラが1台しか検出されません</h2>
+    <p>v2トリガー設計の検証には2台のカメラが必要です。</p>
+    <p>1台のカメラをフロントとサイドの両方に再利用することはできません。</p>
+    <button class="wb-btn" data-wb-action="requestPermission">リトライ</button>
+  </div>
+`;
+
+const renderDeviceOption = (device: MediaDeviceInfo, index: number): string => {
+  const label =
+    device.label !== "" ? device.label : `Camera ${String(index + 1)}`;
+
+  return `<option value="${device.deviceId}">${label}</option>`;
+};
+
+const renderDeviceSelection = (state: WorkbenchState): string => `
+  <div class="wb-screen">
+    <h2>カメラ選択</h2>
+    <p>フロント（照準）とサイド（トリガー）にそれぞれ別のカメラを割り当ててください。</p>
+    <div class="wb-select-row">
+      <label>
+        フロント（照準）:
+        <select id="wb-front-select">
+          ${state.devices.map((d, i) => renderDeviceOption(d, i)).join("")}
+        </select>
+      </label>
+    </div>
+    <div class="wb-select-row">
+      <label>
+        サイド（トリガー）:
+        <select id="wb-side-select">
+          ${state.devices
+            .map((d, i) => renderDeviceOption(d, i))
+            .join("")}
+        </select>
+      </label>
+    </div>
+    <button class="wb-btn" data-wb-action="confirmDevices">確定</button>
+  </div>
+`;
+
+const renderPreviewing = (state: WorkbenchState): string => `
+  <div class="wb-previewing">
+    <h2>ライブプレビュー</h2>
+    <div class="wb-preview-grid">
+      <div class="wb-preview-lane">
+        <h3>フロント（照準）</h3>
+        <p class="wb-device-label">${state.frontAssignment?.label ?? "未選択"}</p>
+        <video id="wb-front-video" autoplay playsinline muted></video>
+      </div>
+      <div class="wb-preview-lane">
+        <h3>サイド（トリガー）</h3>
+        <p class="wb-device-label">${state.sideAssignment?.label ?? "未選択"}</p>
+        <video id="wb-side-video" autoplay playsinline muted></video>
+      </div>
+    </div>
+    <div class="wb-controls">
+      <button class="wb-btn" data-wb-action="swap">左右入れ替え</button>
+      <button class="wb-btn wb-btn-secondary" data-wb-action="reselect">再選択</button>
+    </div>
+  </div>
+`;
+
+export const renderWorkbenchHTML = (state: WorkbenchState): string => {
+  switch (state.screen) {
+    case "permission":
+      return renderPermissionScreen();
+    case "permissionDenied":
+      return renderPermissionDenied();
+    case "singleCamera":
+      return renderSingleCamera();
+    case "deviceSelection":
+      return renderDeviceSelection(state);
+    case "previewing":
+      return renderPreviewing(state);
+  }
+};

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -1,4 +1,5 @@
 import type { WorkbenchState } from "./DiagnosticWorkbench";
+import { escapeHTML } from "../../shared/browser/escapeHTML";
 
 const renderPermissionScreen = (): string => `
   <div class="wb-screen">
@@ -32,7 +33,7 @@ const renderDeviceOption = (device: MediaDeviceInfo, index: number): string => {
   const label =
     device.label !== "" ? device.label : `Camera ${String(index + 1)}`;
 
-  return `<option value="${device.deviceId}">${label}</option>`;
+  return `<option value="${escapeHTML(device.deviceId)}">${escapeHTML(label)}</option>`;
 };
 
 const renderDeviceSelection = (state: WorkbenchState): string => `
@@ -67,12 +68,12 @@ const renderPreviewing = (state: WorkbenchState): string => `
     <div class="wb-preview-grid">
       <div class="wb-preview-lane">
         <h3>フロント（照準）</h3>
-        <p class="wb-device-label">${state.frontAssignment?.label ?? "未選択"}</p>
+        <p class="wb-device-label">${escapeHTML(state.frontAssignment?.label ?? "未選択")}</p>
         <video id="wb-front-video" autoplay playsinline muted></video>
       </div>
       <div class="wb-preview-lane">
         <h3>サイド（トリガー）</h3>
-        <p class="wb-device-label">${state.sideAssignment?.label ?? "未選択"}</p>
+        <p class="wb-device-label">${escapeHTML(state.sideAssignment?.label ?? "未選択")}</p>
         <video id="wb-side-video" autoplay playsinline muted></video>
       </div>
     </div>

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -121,6 +121,7 @@ export const renderWorkbenchHTML = (state: WorkbenchState): string => {
       return renderPermissionScreen();
     case "cameraUnsupported":
     case "permissionDenied":
+    case "permissionFailed":
     case "cameraNotFound":
     case "enumerationFailed":
     case "cameraConstraintFailed":

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -1,4 +1,4 @@
-import type { WorkbenchState } from "./DiagnosticWorkbench";
+import type { WorkbenchError, WorkbenchState } from "./DiagnosticWorkbench";
 import { escapeHTML } from "../../shared/browser/escapeHTML";
 
 const renderPermissionScreen = (): string => `
@@ -9,16 +9,45 @@ const renderPermissionScreen = (): string => `
   </div>
 `;
 
-const renderPermissionDenied = (): string => `
+const fallbackError: WorkbenchError = {
+  kind: "cameraOpenFailed",
+  title: "カメラを開始できません",
+  cause: "カメラ処理中に失敗しました。",
+  impact: "診断ワークベンチを続行できません。",
+  reproduction: "同じ操作をもう一度実行してください。",
+  nextAction: "ページをリロードしてリトライしてください。"
+};
+
+const renderErrorDetails = (error: WorkbenchError | undefined): string => {
+  const detail = error ?? fallbackError;
+
+  return `
   <div class="wb-screen wb-error">
-    <h2>カメラ許可が拒否されました</h2>
-    <p><strong>原因:</strong> ブラウザのカメラ権限が拒否されました。</p>
-    <p><strong>影響:</strong> フロント・サイド両方のキャプチャが開始できません。</p>
-    <p><strong>再現:</strong> リロードしてカメラ権限を拒否してください。</p>
-    <p><strong>対処:</strong> ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。</p>
+    <h2>${escapeHTML(detail.title)}</h2>
+    <p><strong>原因:</strong> ${escapeHTML(detail.cause)}</p>
+    <p><strong>影響:</strong> ${escapeHTML(detail.impact)}</p>
+    <p><strong>再現:</strong> ${escapeHTML(detail.reproduction)}</p>
+    <p><strong>対処:</strong> ${escapeHTML(detail.nextAction)}</p>
     <button class="wb-btn" data-wb-action="requestPermission">リトライ</button>
   </div>
 `;
+};
+
+const renderInlineError = (error: WorkbenchError | undefined): string => {
+  if (error === undefined) {
+    return "";
+  }
+
+  return `
+    <div class="wb-inline-error" role="alert">
+      <strong>${escapeHTML(error.title)}</strong>
+      <p><strong>原因:</strong> ${escapeHTML(error.cause)}</p>
+      <p><strong>影響:</strong> ${escapeHTML(error.impact)}</p>
+      <p><strong>再現:</strong> ${escapeHTML(error.reproduction)}</p>
+      <p><strong>対処:</strong> ${escapeHTML(error.nextAction)}</p>
+    </div>
+  `;
+};
 
 const renderSingleCamera = (): string => `
   <div class="wb-screen wb-warning">
@@ -40,6 +69,7 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
   <div class="wb-screen">
     <h2>カメラ選択</h2>
     <p>フロント（照準）とサイド（トリガー）にそれぞれ別のカメラを割り当ててください。</p>
+    ${renderInlineError(state.error)}
     <div class="wb-select-row">
       <label>
         フロント（照準）:
@@ -65,6 +95,7 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
 const renderPreviewing = (state: WorkbenchState): string => `
   <div class="wb-previewing">
     <h2>ライブプレビュー</h2>
+    ${renderInlineError(state.error)}
     <div class="wb-preview-grid">
       <div class="wb-preview-lane">
         <h3>フロント（照準）</h3>
@@ -88,8 +119,13 @@ export const renderWorkbenchHTML = (state: WorkbenchState): string => {
   switch (state.screen) {
     case "permission":
       return renderPermissionScreen();
+    case "cameraUnsupported":
     case "permissionDenied":
-      return renderPermissionDenied();
+    case "cameraNotFound":
+    case "enumerationFailed":
+    case "cameraConstraintFailed":
+    case "cameraOpenFailed":
+      return renderErrorDetails(state.error);
     case "singleCamera":
       return renderSingleCamera();
     case "deviceSelection":

--- a/src/shared/browser/escapeHTML.ts
+++ b/src/shared/browser/escapeHTML.ts
@@ -1,0 +1,11 @@
+/**
+ * Escape HTML-special characters to prevent injection when
+ * interpolating untrusted strings into HTML template literals.
+ */
+export const escapeHTML = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");

--- a/src/shared/types/camera.ts
+++ b/src/shared/types/camera.ts
@@ -1,0 +1,5 @@
+/**
+ * Identifies which physical role a camera lane serves.
+ * Logs, telemetry, and errors use this to identify the failing role.
+ */
+export type CameraLaneRole = "frontAim" | "sideTrigger";

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -132,3 +132,12 @@ h3 {
 .wb-controls {
   margin-top: 1rem;
 }
+
+.wb-inline-error {
+  border: 2px solid #e74c3c;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1rem 0;
+  background: rgba(231, 76, 60, 0.1);
+  text-align: left;
+}

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -1,0 +1,133 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Segoe UI", "Hiragino Sans", sans-serif;
+  background: #1a1a2e;
+  color: #eee;
+  min-height: 100vh;
+}
+
+#diagnostic-app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+h2 {
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+  color: #7ec8e3;
+}
+
+h3 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  color: #a8d8ea;
+}
+
+.wb-screen {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.wb-screen p {
+  margin-bottom: 0.5rem;
+  line-height: 1.6;
+}
+
+.wb-error {
+  border: 2px solid #e74c3c;
+  border-radius: 8px;
+  padding: 2rem;
+  background: rgba(231, 76, 60, 0.1);
+}
+
+.wb-warning {
+  border: 2px solid #f39c12;
+  border-radius: 8px;
+  padding: 2rem;
+  background: rgba(243, 156, 18, 0.1);
+}
+
+.wb-btn {
+  display: inline-block;
+  margin: 1rem 0.5rem 0;
+  padding: 0.6rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 6px;
+  background: #3498db;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.wb-btn:hover {
+  background: #2980b9;
+}
+
+.wb-btn-secondary {
+  background: #555;
+}
+
+.wb-btn-secondary:hover {
+  background: #777;
+}
+
+.wb-select-row {
+  margin: 0.75rem 0;
+}
+
+.wb-select-row label {
+  display: block;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+}
+
+.wb-select-row select {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.4rem;
+  font-size: 0.95rem;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #2a2a3e;
+  color: #eee;
+}
+
+.wb-previewing {
+  text-align: center;
+}
+
+.wb-preview-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.wb-preview-lane {
+  background: #16213e;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.wb-preview-lane video {
+  width: 100%;
+  border-radius: 4px;
+  background: #000;
+}
+
+.wb-device-label {
+  font-size: 0.8rem;
+  color: #888;
+  margin-bottom: 0.5rem;
+}
+
+.wb-controls {
+  margin-top: 1rem;
+}

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -1,10 +1,11 @@
-* {
+#diagnostic-app * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
 body {
+  margin: 0;
   font-family: "Segoe UI", "Hiragino Sans", sans-serif;
   background: #1a1a2e;
   color: #eee;

--- a/tests/e2e/diagnostic.smoke.spec.ts
+++ b/tests/e2e/diagnostic.smoke.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type FakeCameraMode = "ok" | "permissionDenied";
+
+interface FakeCameraDevice {
+  readonly deviceId: string;
+  readonly label: string;
+}
+
+const installFakeCameras = async (
+  page: Page,
+  devices: FakeCameraDevice[],
+  mode: FakeCameraMode = "ok"
+): Promise<void> => {
+  await page.addInitScript(
+    ({ fakeDevices, fakeMode }) => {
+      Object.defineProperty(navigator, "mediaDevices", {
+        configurable: true,
+        value: {
+          enumerateDevices: () =>
+            Promise.resolve(
+              fakeDevices.map((device) => ({
+                kind: "videoinput",
+                deviceId: device.deviceId,
+                label: device.label,
+                groupId: `${device.deviceId}-group`,
+                toJSON: () => ({})
+              }))
+            ),
+          getUserMedia: () => {
+            if (fakeMode === "permissionDenied") {
+              return Promise.reject(
+                new DOMException("Camera denied", "NotAllowedError")
+              );
+            }
+
+            return Promise.resolve(new MediaStream());
+          }
+        }
+      });
+    },
+    { fakeDevices: devices, fakeMode: mode }
+  );
+};
+
+test("diagnostic workbench runs permission, device selection, previews, swap, and reselect", async ({
+  page
+}) => {
+  await installFakeCameras(page, [
+    { deviceId: "front-device-id", label: "Front Camera" },
+    { deviceId: "side-device-id", label: "Side Camera" }
+  ]);
+
+  await page.goto("/diagnostic.html");
+  await page.getByRole("button", { name: "カメラ許可" }).click();
+
+  await expect(page.getByRole("heading", { name: "カメラ選択" })).toBeVisible();
+  await page.locator("#wb-front-select").selectOption("front-device-id");
+  await page.locator("#wb-side-select").selectOption("side-device-id");
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByRole("heading", { name: "ライブプレビュー" })).toBeVisible();
+  await expect(page.locator("#wb-front-video")).toBeVisible();
+  await expect(page.locator("#wb-side-video")).toBeVisible();
+  await expect(page.locator(".wb-preview-lane").first()).toContainText("Front Camera");
+  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText("Side Camera");
+
+  await page.getByRole("button", { name: "左右入れ替え" }).click();
+  await expect(page.locator(".wb-preview-lane").first()).toContainText("Side Camera");
+  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText("Front Camera");
+
+  await page.getByRole("button", { name: "再選択" }).click();
+  await expect(page.getByRole("heading", { name: "カメラ選択" })).toBeVisible();
+});
+
+test("diagnostic workbench shows permission denial details", async ({ page }) => {
+  await installFakeCameras(
+    page,
+    [{ deviceId: "front-device-id", label: "Front Camera" }],
+    "permissionDenied"
+  );
+
+  await page.goto("/diagnostic.html");
+  await page.getByRole("button", { name: "カメラ許可" }).click();
+
+  await expect(page.getByRole("heading", { name: "カメラ許可が拒否されました" })).toBeVisible();
+  await expect(page.getByText("原因:")).toBeVisible();
+  await expect(page.getByText("影響:")).toBeVisible();
+  await expect(page.getByText("再現:")).toBeVisible();
+  await expect(page.getByText("対処:")).toBeVisible();
+});
+
+test("diagnostic workbench warns when only one camera is available", async ({ page }) => {
+  await installFakeCameras(page, [
+    { deviceId: "front-device-id", label: "Front Camera" }
+  ]);
+
+  await page.goto("/diagnostic.html");
+  await page.getByRole("button", { name: "カメラ許可" }).click();
+
+  await expect(page.getByRole("heading", { name: "カメラが1台しか検出されません" })).toBeVisible();
+  await expect(
+    page.getByText("1台のカメラをフロントとサイドの両方に再利用することはできません")
+  ).toBeVisible();
+});

--- a/tests/e2e/home.smoke.spec.ts
+++ b/tests/e2e/home.smoke.spec.ts
@@ -4,4 +4,5 @@ test("home page renders the v2 setup placeholder", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "BalloonShoot v2" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "diagnostic.html" })).toBeVisible();
 });

--- a/tests/e2e/home.smoke.spec.ts
+++ b/tests/e2e/home.smoke.spec.ts
@@ -4,5 +4,8 @@ test("home page renders the v2 setup placeholder", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "BalloonShoot v2" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "diagnostic.html" })).toBeVisible();
+  const diagnosticLink = page.getByRole("link", { name: "diagnostic.html" });
+
+  await expect(diagnosticLink).toBeVisible();
+  await expect(diagnosticLink).toHaveAttribute("href", "./diagnostic.html");
 });

--- a/tests/unit/features/camera/cameraPermission.test.ts
+++ b/tests/unit/features/camera/cameraPermission.test.ts
@@ -49,6 +49,32 @@ describe("requestCameraPermission", () => {
     expect(result.status).toBe("denied");
   });
 
+  it("returns notFound when no camera device is available", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi
+          .fn()
+          .mockRejectedValue(createPermissionError("NotFoundError"))
+      }
+    });
+
+    const result = await requestCameraPermission();
+
+    expect(result.status).toBe("notFound");
+  });
+
+  it("returns failed for camera permission errors without a specific recovery path", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockRejectedValue(createPermissionError("AbortError"))
+      }
+    });
+
+    const result = await requestCameraPermission();
+
+    expect(result.status).toBe("failed");
+  });
+
   it("returns unsupported when mediaDevices or getUserMedia is missing", async () => {
     vi.stubGlobal("navigator", {});
 

--- a/tests/unit/features/camera/cameraPermission.test.ts
+++ b/tests/unit/features/camera/cameraPermission.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requestCameraPermission } from "../../../../src/features/camera/cameraPermission";
+
+const createTrack = () => ({
+  stop: vi.fn()
+});
+
+const createPermissionError = (name: string): Error =>
+  Object.assign(new Error(name), { name });
+
+describe("requestCameraPermission", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns granted and stops the temporary permission stream", async () => {
+    const firstTrack = createTrack();
+    const secondTrack = createTrack();
+    const getUserMedia = vi.fn().mockResolvedValue({
+      getTracks: () => [firstTrack, secondTrack]
+    });
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia }
+    });
+
+    const result = await requestCameraPermission();
+
+    expect(result).toEqual({ status: "granted" });
+    expect(getUserMedia).toHaveBeenCalledWith({
+      video: true,
+      audio: false
+    });
+    expect(firstTrack.stop).toHaveBeenCalledOnce();
+    expect(secondTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it("returns denied when the browser rejects camera permission", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi
+          .fn()
+          .mockRejectedValue(createPermissionError("NotAllowedError"))
+      }
+    });
+
+    const result = await requestCameraPermission();
+
+    expect(result.status).toBe("denied");
+  });
+
+  it("returns unsupported when mediaDevices or getUserMedia is missing", async () => {
+    vi.stubGlobal("navigator", {});
+
+    const result = await requestCameraPermission();
+
+    expect(result.status).toBe("unsupported");
+  });
+});

--- a/tests/unit/features/camera/createDevicePinnedStream.test.ts
+++ b/tests/unit/features/camera/createDevicePinnedStream.test.ts
@@ -32,6 +32,14 @@ describe("createDevicePinnedStream", () => {
     expect(pinned.deviceId).toBe("front-device-id");
   });
 
+  it("throws when getUserMedia is unavailable", async () => {
+    vi.stubGlobal("navigator", {});
+
+    await expect(createDevicePinnedStream("front-device-id")).rejects.toThrow(
+      "navigator.mediaDevices.getUserMedia is unavailable."
+    );
+  });
+
   it("stops every track on the pinned stream", async () => {
     const firstTrack = createTrack();
     const secondTrack = createTrack();

--- a/tests/unit/features/camera/createDevicePinnedStream.test.ts
+++ b/tests/unit/features/camera/createDevicePinnedStream.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDevicePinnedStream } from "../../../../src/features/camera/createDevicePinnedStream";
+
+const createTrack = () => ({
+  stop: vi.fn()
+});
+
+describe("createDevicePinnedStream", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens getUserMedia with an exact deviceId constraint", async () => {
+    const stream = { getTracks: () => [] };
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia }
+    });
+
+    const pinned = await createDevicePinnedStream("front-device-id");
+
+    expect(getUserMedia).toHaveBeenCalledWith({
+      video: {
+        deviceId: { exact: "front-device-id" },
+        width: { ideal: 640 },
+        height: { ideal: 480 }
+      },
+      audio: false
+    });
+    expect(pinned.stream).toBe(stream);
+    expect(pinned.deviceId).toBe("front-device-id");
+  });
+
+  it("stops every track on the pinned stream", async () => {
+    const firstTrack = createTrack();
+    const secondTrack = createTrack();
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getTracks: () => [firstTrack, secondTrack]
+        })
+      }
+    });
+
+    const pinned = await createDevicePinnedStream("side-device-id");
+
+    pinned.stop();
+
+    expect(firstTrack.stop).toHaveBeenCalledOnce();
+    expect(secondTrack.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/features/camera/enumerateVideoDevices.test.ts
+++ b/tests/unit/features/camera/enumerateVideoDevices.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { enumerateVideoDevices } from "../../../../src/features/camera/enumerateVideoDevices";
+
+const createDevice = (
+  kind: MediaDeviceKind,
+  deviceId: string,
+  label: string
+): MediaDeviceInfo =>
+  ({
+    kind,
+    deviceId,
+    label,
+    groupId: `${deviceId}-group`,
+    toJSON: () => ({})
+  }) as MediaDeviceInfo;
+
+describe("enumerateVideoDevices", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns only videoinput devices", async () => {
+    const front = createDevice("videoinput", "front-id", "Front");
+    const side = createDevice("videoinput", "side-id", "Side");
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        enumerateDevices: vi
+          .fn()
+          .mockResolvedValue([
+            front,
+            createDevice("audioinput", "mic-id", "Mic"),
+            side,
+            createDevice("audiooutput", "speaker-id", "Speaker")
+          ])
+      }
+    });
+
+    const result = await enumerateVideoDevices();
+
+    expect(result).toEqual([front, side]);
+  });
+});

--- a/tests/unit/features/camera/enumerateVideoDevices.test.ts
+++ b/tests/unit/features/camera/enumerateVideoDevices.test.ts
@@ -40,4 +40,12 @@ describe("enumerateVideoDevices", () => {
 
     expect(result).toEqual([front, side]);
   });
+
+  it("throws when enumerateDevices is unavailable", async () => {
+    vi.stubGlobal("navigator", {});
+
+    await expect(enumerateVideoDevices()).rejects.toThrow(
+      "navigator.mediaDevices.enumerateDevices is unavailable."
+    );
+  });
 });

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestCameraPermission } from "../../../../src/features/camera/cameraPermission";
+import { createDevicePinnedStream } from "../../../../src/features/camera/createDevicePinnedStream";
+import type { DevicePinnedStream } from "../../../../src/features/camera/createDevicePinnedStream";
+import { enumerateVideoDevices } from "../../../../src/features/camera/enumerateVideoDevices";
+import { createDiagnosticWorkbench } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
+
+vi.mock("../../../../src/features/camera/cameraPermission", () => ({
+  requestCameraPermission: vi.fn()
+}));
+
+vi.mock("../../../../src/features/camera/enumerateVideoDevices", () => ({
+  enumerateVideoDevices: vi.fn()
+}));
+
+vi.mock("../../../../src/features/camera/createDevicePinnedStream", () => ({
+  createDevicePinnedStream: vi.fn()
+}));
+
+const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
+  ({
+    kind: "videoinput",
+    deviceId,
+    label,
+    groupId: `${deviceId}-group`,
+    toJSON: () => ({})
+  }) as MediaDeviceInfo;
+
+interface FakeDevicePinnedStream extends DevicePinnedStream {
+  readonly stopMock: ReturnType<typeof vi.fn>;
+}
+
+const createPinnedStream = (deviceId: string): FakeDevicePinnedStream => {
+  const stopMock = vi.fn();
+
+  return {
+    stream: { id: `${deviceId}-stream` } as MediaStream,
+    deviceId,
+    stopMock,
+    stop() {
+      stopMock();
+    }
+  };
+};
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
+const createCameraError = (name: string): Error =>
+  Object.assign(new Error(name), { name });
+
+const grantPermission = () => {
+  vi.mocked(requestCameraPermission).mockResolvedValue({ status: "granted" });
+};
+
+const enumerateTwoDevices = () => {
+  vi.mocked(enumerateVideoDevices).mockResolvedValue([
+    createDevice("front-id", "Front Camera"),
+    createDevice("side-id", "")
+  ]);
+};
+
+describe("createDiagnosticWorkbench", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders permissionDenied state for denied camera permission", async () => {
+    vi.mocked(requestCameraPermission).mockResolvedValue({
+      status: "denied",
+      error: createCameraError("NotAllowedError")
+    });
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+
+    expect(workbench.getState().screen).toBe("permissionDenied");
+    expect(workbench.getState().error?.kind).toBe("permissionDenied");
+    expect(enumerateVideoDevices).not.toHaveBeenCalled();
+  });
+
+  it("renders singleCamera when fewer than two video inputs are available", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("front-id", "Front Camera")
+    ]);
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+
+    expect(workbench.getState().screen).toBe("singleCamera");
+    expect(workbench.getState().devices).toHaveLength(1);
+  });
+
+  it("renders deviceSelection after permission and two-camera enumeration", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(workbench.getState().devices.map((d) => d.deviceId)).toEqual([
+      "front-id",
+      "side-id"
+    ]);
+  });
+
+  it("opens selected devices and assigns safe preview labels", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+
+    expect(workbench.getState()).toMatchObject({
+      screen: "previewing",
+      frontAssignment: { label: "Front Camera" },
+      sideAssignment: { label: "Camera 2" },
+      frontStream,
+      sideStream
+    });
+  });
+
+  it("keeps same-device assignment errors in UI state instead of rejecting", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+
+    await expect(workbench.assignDevices("front-id", "front-id")).resolves.toBeUndefined();
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(workbench.getState().error?.kind).toBe("distinctDevicesRequired");
+  });
+
+  it("stops a successful first stream when the paired side stream fails", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockRejectedValueOnce(createCameraError("OverconstrainedError"));
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("cameraConstraintFailed");
+    expect(workbench.getState().error?.kind).toBe("cameraConstraintFailed");
+    expect(workbench.getState().frontStream).toBeUndefined();
+  });
+
+  it("keeps existing preview streams when swap opening fails", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    const attemptedSwapStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream)
+      .mockResolvedValueOnce(attemptedSwapStream)
+      .mockRejectedValueOnce(createCameraError("OverconstrainedError"));
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    await workbench.swapRoles();
+
+    expect(attemptedSwapStream.stopMock).toHaveBeenCalledOnce();
+    expect(frontStream.stopMock).not.toHaveBeenCalled();
+    expect(sideStream.stopMock).not.toHaveBeenCalled();
+    expect(workbench.getState().screen).toBe("previewing");
+    expect(workbench.getState().frontStream).toBe(frontStream);
+    expect(workbench.getState().sideStream).toBe(sideStream);
+    expect(workbench.getState().error?.kind).toBe("cameraConstraintFailed");
+  });
+
+  it("stops current and stale in-flight streams when reselect advances generation", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontDeferred = createDeferred<DevicePinnedStream>();
+    const sideDeferred = createDeferred<DevicePinnedStream>();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockReturnValueOnce(frontDeferred.promise)
+      .mockReturnValueOnce(sideDeferred.promise);
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    const assignment = workbench.assignDevices("front-id", "side-id");
+
+    frontDeferred.resolve(frontStream);
+    await Promise.resolve();
+    workbench.reselect();
+    sideDeferred.resolve(sideStream);
+    await assignment;
+
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(sideStream.stopMock).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(workbench.getState().frontStream).toBeUndefined();
+  });
+
+  it("stops streams returned after destroy invalidates an in-flight open", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontDeferred = createDeferred<DevicePinnedStream>();
+    const sideDeferred = createDeferred<DevicePinnedStream>();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockReturnValueOnce(frontDeferred.promise)
+      .mockReturnValueOnce(sideDeferred.promise);
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    const assignment = workbench.assignDevices("front-id", "side-id");
+
+    frontDeferred.resolve(frontStream);
+    await Promise.resolve();
+    workbench.destroy();
+    sideDeferred.resolve(sideStream);
+    await assignment;
+
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(sideStream.stopMock).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("deviceSelection");
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -88,7 +88,36 @@ describe("createDiagnosticWorkbench", () => {
     expect(enumerateVideoDevices).not.toHaveBeenCalled();
   });
 
-  it("renders singleCamera when fewer than two video inputs are available", async () => {
+  it("renders permissionFailed state for non-denied permission failures", async () => {
+    vi.mocked(requestCameraPermission).mockResolvedValue({
+      status: "failed",
+      error: createCameraError("AbortError")
+    });
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+
+    expect(workbench.getState().screen).toBe("permissionFailed");
+    expect(workbench.getState().error?.kind).toBe("permissionFailed");
+    expect(workbench.getState().error?.impact).toContain("カメラ許可");
+    expect(enumerateVideoDevices).not.toHaveBeenCalled();
+  });
+
+  it("renders cameraNotFound when no video inputs remain after permission", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([]);
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+
+    expect(workbench.getState().screen).toBe("cameraNotFound");
+    expect(workbench.getState().devices).toEqual([]);
+    expect(workbench.getState().error?.kind).toBe("cameraNotFound");
+  });
+
+  it("renders singleCamera when exactly one video input is available", async () => {
     grantPermission();
     vi.mocked(enumerateVideoDevices).mockResolvedValue([
       createDevice("front-id", "Front Camera")

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -146,6 +146,71 @@ describe("createDiagnosticWorkbench", () => {
     ]);
   });
 
+  it("keeps newer permission results when an older permission request resolves later", async () => {
+    const firstPermission =
+      createDeferred<Awaited<ReturnType<typeof requestCameraPermission>>>();
+    vi.mocked(requestCameraPermission)
+      .mockReturnValueOnce(firstPermission.promise)
+      .mockResolvedValueOnce({ status: "granted" });
+    let enumerationCount = 0;
+    vi.mocked(enumerateVideoDevices).mockImplementation(() => {
+      enumerationCount += 1;
+      const devices =
+        enumerationCount === 1
+          ? [
+              createDevice("front-id", "Front Camera"),
+              createDevice("side-id", "Side Camera")
+            ]
+          : [createDevice("stale-id", "Stale Camera")];
+
+      return Promise.resolve(devices);
+    });
+
+    const workbench = createDiagnosticWorkbench();
+    const firstRequest = workbench.requestPermission();
+    const secondRequest = workbench.requestPermission();
+
+    await secondRequest;
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(workbench.getState().devices.map((d) => d.deviceId)).toEqual([
+      "front-id",
+      "side-id"
+    ]);
+
+    firstPermission.resolve({ status: "granted" });
+    await firstRequest;
+
+    expect(enumerateVideoDevices).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(workbench.getState().devices.map((d) => d.deviceId)).toEqual([
+      "front-id",
+      "side-id"
+    ]);
+  });
+
+  it("ignores pending permission results after destroy", async () => {
+    const permission =
+      createDeferred<Awaited<ReturnType<typeof requestCameraPermission>>>();
+    vi.mocked(requestCameraPermission).mockReturnValueOnce(permission.promise);
+    enumerateTwoDevices();
+
+    const workbench = createDiagnosticWorkbench();
+    const listener = vi.fn();
+    workbench.subscribe(listener);
+
+    const request = workbench.requestPermission();
+    expect(listener).toHaveBeenCalledOnce();
+
+    workbench.destroy();
+    permission.resolve({ status: "granted" });
+    await request;
+
+    expect(enumerateVideoDevices).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("permission");
+    expect(workbench.getState().devices).toEqual([]);
+  });
+
   it("opens selected devices and assigns safe preview labels", async () => {
     grantPermission();
     enumerateTwoDevices();
@@ -222,6 +287,39 @@ describe("createDiagnosticWorkbench", () => {
     expect(workbench.getState().frontStream).toBe(frontStream);
     expect(workbench.getState().sideStream).toBe(sideStream);
     expect(workbench.getState().error?.kind).toBe("cameraConstraintFailed");
+  });
+
+  it("stops existing preview streams when requesting permission again", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    const permission =
+      createDeferred<Awaited<ReturnType<typeof requestCameraPermission>>>();
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    vi.mocked(requestCameraPermission).mockReturnValueOnce(permission.promise);
+
+    const request = workbench.requestPermission();
+
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(sideStream.stopMock).toHaveBeenCalledOnce();
+    expect(workbench.getState()).toMatchObject({
+      screen: "permission",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: undefined,
+      sideStream: undefined
+    });
+
+    permission.resolve({ status: "granted" });
+    await request;
   });
 
   it("stops current and stale in-flight streams when reselect advances generation", async () => {

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type {
+  WorkbenchError,
+  WorkbenchState
+} from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
+import { renderWorkbenchHTML } from "../../../../src/features/diagnostic-workbench/renderWorkbench";
+
+const createState = (patch: Partial<WorkbenchState>): WorkbenchState => ({
+  screen: "permission",
+  devices: [],
+  frontAssignment: undefined,
+  sideAssignment: undefined,
+  frontStream: undefined,
+  sideStream: undefined,
+  error: undefined,
+  ...patch
+});
+
+const createError = (kind: WorkbenchError["kind"]): WorkbenchError => ({
+  kind,
+  title: "テストエラー",
+  cause: "原因 <script>",
+  impact: "影響",
+  reproduction: "再現",
+  nextAction: "対処"
+});
+
+const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
+  ({
+    kind: "videoinput",
+    deviceId,
+    label,
+    groupId: `${deviceId}-group`,
+    toJSON: () => ({})
+  }) as MediaDeviceInfo;
+
+describe("renderWorkbenchHTML", () => {
+  it("renders the permission screen", () => {
+    const html = renderWorkbenchHTML(createState({ screen: "permission" }));
+
+    expect(html).toContain("診断ワークベンチ");
+    expect(html).toContain('data-wb-action="requestPermission"');
+  });
+
+  it("renders diagnostic error screens with cause, impact, reproduction, and next action", () => {
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "cameraConstraintFailed",
+        error: createError("cameraConstraintFailed")
+      })
+    );
+
+    expect(html).toContain("テストエラー");
+    expect(html).toContain("<strong>原因:</strong>");
+    expect(html).toContain("<strong>影響:</strong>");
+    expect(html).toContain("<strong>再現:</strong>");
+    expect(html).toContain("<strong>対処:</strong>");
+    expect(html).toContain("原因 &lt;script&gt;");
+    expect(html).not.toContain("原因 <script>");
+  });
+
+  it("renders a single-camera warning", () => {
+    const html = renderWorkbenchHTML(createState({ screen: "singleCamera" }));
+
+    expect(html).toContain("カメラが1台しか検出されません");
+    expect(html).toContain("1台のカメラをフロントとサイドの両方に再利用することはできません");
+  });
+
+  it("escapes device labels and ids in device selection", () => {
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "deviceSelection",
+        devices: [
+          createDevice('front"><script>', "Front <script>"),
+          createDevice("side-id", "")
+        ]
+      })
+    );
+
+    expect(html).toContain("Front &lt;script&gt;");
+    expect(html).toContain('value="front&quot;&gt;&lt;script&gt;"');
+    expect(html).not.toContain("Front <script>");
+  });
+
+  it("renders preview labels without falling back to raw deviceId prefixes", () => {
+    const rawFrontId = "front-secret-device-id";
+    const rawSideId = "side-secret-device-id";
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "previewing",
+        frontAssignment: {
+          role: "frontAim",
+          deviceId: rawFrontId,
+          label: "Camera 1"
+        },
+        sideAssignment: {
+          role: "sideTrigger",
+          deviceId: rawSideId,
+          label: "Side <Camera>"
+        }
+      })
+    );
+
+    expect(html).toContain("Camera 1");
+    expect(html).toContain("Side &lt;Camera&gt;");
+    expect(html).not.toContain(rawFrontId.slice(0, 8));
+    expect(html).not.toContain(rawSideId.slice(0, 8));
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
   WorkbenchError,
+  WorkbenchScreen,
   WorkbenchState
 } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
 import { renderWorkbenchHTML } from "../../../../src/features/diagnostic-workbench/renderWorkbench";
@@ -42,21 +43,46 @@ describe("renderWorkbenchHTML", () => {
     expect(html).toContain('data-wb-action="requestPermission"');
   });
 
-  it("renders diagnostic error screens with cause, impact, reproduction, and next action", () => {
+  it.each<Exclude<WorkbenchError["kind"], "distinctDevicesRequired">>([
+    "cameraUnsupported",
+    "permissionDenied",
+    "permissionFailed",
+    "cameraNotFound",
+    "enumerationFailed",
+    "cameraConstraintFailed",
+    "cameraOpenFailed"
+  ])(
+    "renders %s error screens with cause, impact, reproduction, and next action",
+    (kind) => {
+      const html = renderWorkbenchHTML(
+        createState({
+          screen: kind as WorkbenchScreen,
+          error: createError(kind)
+        })
+      );
+
+      expect(html).toContain("テストエラー");
+      expect(html).toContain("<strong>原因:</strong>");
+      expect(html).toContain("<strong>影響:</strong>");
+      expect(html).toContain("<strong>再現:</strong>");
+      expect(html).toContain("<strong>対処:</strong>");
+      expect(html).toContain("原因 &lt;script&gt;");
+      expect(html).not.toContain("原因 <script>");
+    }
+  );
+
+  it("renders diagnostic fallback error details when an error screen has no error object", () => {
     const html = renderWorkbenchHTML(
       createState({
-        screen: "cameraConstraintFailed",
-        error: createError("cameraConstraintFailed")
+        screen: "cameraConstraintFailed"
       })
     );
 
-    expect(html).toContain("テストエラー");
+    expect(html).toContain("カメラを開始できません");
     expect(html).toContain("<strong>原因:</strong>");
     expect(html).toContain("<strong>影響:</strong>");
     expect(html).toContain("<strong>再現:</strong>");
     expect(html).toContain("<strong>対処:</strong>");
-    expect(html).toContain("原因 &lt;script&gt;");
-    expect(html).not.toContain("原因 <script>");
   });
 
   it("renders a single-camera warning", () => {
@@ -78,6 +104,7 @@ describe("renderWorkbenchHTML", () => {
     );
 
     expect(html).toContain("Front &lt;script&gt;");
+    expect(html).toContain("Camera 2");
     expect(html).toContain('value="front&quot;&gt;&lt;script&gt;"');
     expect(html).not.toContain("Front <script>");
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,17 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
     host: "127.0.0.1",
     port: 5173
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        diagnostic: resolve(__dirname, "diagnostic.html")
+      }
+    }
   }
 });


### PR DESCRIPTION
Supersedes #10. Rebuilt on top of main after the v1 retirement (#13) and resolves the Codex review / advisor follow-ups that surfaced on the original M1 stack.

## Summary

- Independent Vite entries: `index.html` (v2 placeholder with link to the workbench) and `diagnostic.html` (diagnostic workbench page)
- `src/features/camera/`: `cameraPermission`, `enumerateVideoDevices`, `createDevicePinnedStream` — no `createCameraController` revival
- `src/features/diagnostic-workbench/`: controller + renderer for permission → device selection → previewing with swap and reselect
- Deterministic camera role assignment (`frontAim` / `sideTrigger`), deviceId-pinned streams, label-first preview naming
- Live camera previews attached via `<video srcObject>` with HTML-escaped labels

## Codex follow-up items resolved

Correctness (from Codex review P2 + advisor pass):
- Sequential `getUserMedia` open with cleanup on partial pairing failure; swap is transactional so an already-working preview never dies for a transient side-camera reject.
- `reselect()` / `destroy()` advance an `openGeneration` counter so any stream that resolves after the user moved on is stopped instead of being applied to state.
- `requestCameraPermission()` returns a discriminated result (`granted` / `denied` / `notFound` / `unsupported` / `failed`) so the UI surfaces cause, impact, reproduction, and next action per plan §4 — no more flattening every failure to "permission denied".
- Raw `deviceId` prefix is gone from the UI; the preview uses the browser label and falls back to a `Camera N` slot when the label is empty.
- `diagnostic-main.ts` awaits async actions with `.catch()` so rejected promises become workbench state instead of unhandled rejections.

Test coverage (v2 plan §8, TDD — RED/GREEN, 11 initial failures observed):
- `tests/unit/features/camera/*.test.ts` — permission result shape, device enumeration filtering, exact-deviceId constraint, `stop()` semantics
- `tests/unit/features/diagnostic-workbench/*.test.ts` — permission denial, single-camera warning, device selection, distinct-device rejection, swap rollback, reselect cleanup, destroy cancellation, HTML escape
- `tests/e2e/diagnostic.smoke.spec.ts` — Playwright automation of the original PR #10 review checklist (permission → selection → previews, swap, reselect, permission denial, single-camera warning) driven by injected fake `mediaDevices`
- `tests/e2e/home.smoke.spec.ts` extended to assert the `diagnostic.html` link

## Review & testing checklist

- [ ] `npm run lint`, `typecheck`, `knip`, `test`, `test:replay`, `build`, `test:e2e` all green (all confirmed locally)
- [ ] `/` renders the v2 placeholder and the diagnostic link resolves
- [ ] `/diagnostic.html` runs the permission flow end to end with two physical cameras

## Relation to #10

Same scope as #10, same branch family, but regenerated on top of post-cleanup main so that the required CI contexts (`knip`, `replay`, `e2e`, `CodeRabbit`) can stay green without relying on v1 code paths. #10 can be closed once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/balloonshoot_v2/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New features**
  * Added the diagnostic workbench. Reachable from the main page; supports camera selection, live preview, role assignment, and camera switching.
* **Documentation**
  * Added a guidance document describing the diagnostic workbench's responsibilities and behavior.
* **Style**
  * Added diagnostic UI styles to clean up layout, buttons, and preview rendering.
* **Tests**
  * Added e2e and unit tests verifying camera permission, enumeration, and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
