### PR TITLE
feat(M3): Diagnostic Workbench Landmark Inspection

### DIFF
--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -4,6 +4,7 @@ import {
   type DiagnosticWorkbench
 } from "./features/diagnostic-workbench/DiagnosticWorkbench";
 import { renderWorkbenchHTML } from "./features/diagnostic-workbench/renderWorkbench";
+import { createLiveLandmarkInspection } from "./features/diagnostic-workbench/liveLandmarkInspection";
 
 const root = document.querySelector<HTMLDivElement>("#diagnostic-app");
 
@@ -12,11 +13,14 @@ if (!root) {
 }
 
 const workbench: DiagnosticWorkbench = createDiagnosticWorkbench();
+const liveInspection = createLiveLandmarkInspection();
 
 const render = (): void => {
   const state = workbench.getState();
-  root.innerHTML = renderWorkbenchHTML(state);
+  root.innerHTML = renderWorkbenchHTML(state, liveInspection.getState());
   attachVideoStreams(state);
+  liveInspection.sync(state);
+  liveInspection.updateDom();
 };
 
 const attachVideoStreams = (
@@ -26,15 +30,30 @@ const attachVideoStreams = (
     return;
   }
 
-  const frontVideo = document.querySelector<HTMLVideoElement>("#wb-front-video");
+  const frontVideo =
+    document.querySelector<HTMLVideoElement>("#wb-front-video");
+  const frontFilteredVideo = document.querySelector<HTMLVideoElement>(
+    "#wb-front-filtered-video"
+  );
   const sideVideo = document.querySelector<HTMLVideoElement>("#wb-side-video");
+  const sideFilteredVideo = document.querySelector<HTMLVideoElement>(
+    "#wb-side-filtered-video"
+  );
 
   if (frontVideo !== null && state.frontStream !== undefined) {
     frontVideo.srcObject = state.frontStream.stream;
   }
 
+  if (frontFilteredVideo !== null && state.frontStream !== undefined) {
+    frontFilteredVideo.srcObject = state.frontStream.stream;
+  }
+
   if (sideVideo !== null && state.sideStream !== undefined) {
     sideVideo.srcObject = state.sideStream.stream;
+  }
+
+  if (sideFilteredVideo !== null && state.sideStream !== undefined) {
+    sideFilteredVideo.srcObject = state.sideStream.stream;
   }
 };
 
@@ -94,6 +113,10 @@ const handleClick = (e: MouseEvent): void => {
 
 root.addEventListener("click", handleClick);
 workbench.subscribe(render);
+window.addEventListener("beforeunload", () => {
+  liveInspection.destroy();
+  workbench.destroy();
+});
 
 // Initial render
 render();

--- a/src/features/camera/frameTimestamp.ts
+++ b/src/features/camera/frameTimestamp.ts
@@ -1,0 +1,50 @@
+import type {
+  FrameTimestamp,
+  TimestampSource
+} from "../../shared/types/camera";
+
+interface FrameTimingMetadata {
+  readonly captureTime?: number;
+  readonly expectedDisplayTime?: number;
+  readonly presentedFrames?: number;
+}
+
+const isUsableTimestamp = (value: number | undefined): value is number =>
+  value !== undefined && Number.isFinite(value);
+
+const selectTimestamp = (
+  metadata: FrameTimingMetadata,
+  receivedAtPerformanceMs: number
+): { frameTimestampMs: number; timestampSource: TimestampSource } => {
+  if (isUsableTimestamp(metadata.captureTime)) {
+    return {
+      frameTimestampMs: metadata.captureTime,
+      timestampSource: "requestVideoFrameCallbackCaptureTime"
+    };
+  }
+
+  if (isUsableTimestamp(metadata.expectedDisplayTime)) {
+    return {
+      frameTimestampMs: metadata.expectedDisplayTime,
+      timestampSource: "requestVideoFrameCallbackExpectedDisplayTime"
+    };
+  }
+
+  return {
+    frameTimestampMs: receivedAtPerformanceMs,
+    timestampSource: "performanceNowAtCallback"
+  };
+};
+
+export const createFrameTimestamp = (
+  metadata: FrameTimingMetadata,
+  receivedAtPerformanceMs: number
+): FrameTimestamp => {
+  const selected = selectTimestamp(metadata, receivedAtPerformanceMs);
+
+  return {
+    ...selected,
+    presentedFrames: metadata.presentedFrames,
+    receivedAtPerformanceMs
+  };
+};

--- a/src/features/diagnostic-workbench/landmarkOverlay.ts
+++ b/src/features/diagnostic-workbench/landmarkOverlay.ts
@@ -1,19 +1,19 @@
 import type { HandFrame, HandLandmarkSet } from "../../shared/types/hand";
 
-export type OverlayLandmarkName = keyof HandLandmarkSet;
+type OverlayLandmarkName = keyof HandLandmarkSet;
 
-export interface LandmarkOverlayPoint {
+interface LandmarkOverlayPoint {
   readonly name: OverlayLandmarkName;
   readonly x: number;
   readonly y: number;
 }
 
-export interface LandmarkOverlayConnection {
+interface LandmarkOverlayConnection {
   readonly from: OverlayLandmarkName;
   readonly to: OverlayLandmarkName;
 }
 
-export interface LandmarkOverlayModel {
+interface LandmarkOverlayModel {
   readonly width: number;
   readonly height: number;
   readonly points: LandmarkOverlayPoint[];
@@ -31,7 +31,7 @@ const LANDMARK_NAMES = [
   "pinkyTip"
 ] as const satisfies readonly OverlayLandmarkName[];
 
-export const LANDMARK_CONNECTIONS = [
+const LANDMARK_CONNECTIONS = [
   { from: "wrist", to: "thumbIp" },
   { from: "thumbIp", to: "thumbTip" },
   { from: "wrist", to: "indexMcp" },

--- a/src/features/diagnostic-workbench/landmarkOverlay.ts
+++ b/src/features/diagnostic-workbench/landmarkOverlay.ts
@@ -1,0 +1,55 @@
+import type { HandFrame, HandLandmarkSet } from "../../shared/types/hand";
+
+export type OverlayLandmarkName = keyof HandLandmarkSet;
+
+export interface LandmarkOverlayPoint {
+  readonly name: OverlayLandmarkName;
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface LandmarkOverlayConnection {
+  readonly from: OverlayLandmarkName;
+  readonly to: OverlayLandmarkName;
+}
+
+export interface LandmarkOverlayModel {
+  readonly width: number;
+  readonly height: number;
+  readonly points: LandmarkOverlayPoint[];
+  readonly connections: LandmarkOverlayConnection[];
+}
+
+const LANDMARK_NAMES = [
+  "wrist",
+  "thumbIp",
+  "thumbTip",
+  "indexMcp",
+  "indexTip",
+  "middleTip",
+  "ringTip",
+  "pinkyTip"
+] as const satisfies readonly OverlayLandmarkName[];
+
+export const LANDMARK_CONNECTIONS = [
+  { from: "wrist", to: "thumbIp" },
+  { from: "thumbIp", to: "thumbTip" },
+  { from: "wrist", to: "indexMcp" },
+  { from: "indexMcp", to: "indexTip" },
+  { from: "wrist", to: "middleTip" },
+  { from: "middleTip", to: "ringTip" },
+  { from: "ringTip", to: "pinkyTip" }
+] as const satisfies readonly LandmarkOverlayConnection[];
+
+export const createLandmarkOverlayModel = (
+  frame: HandFrame
+): LandmarkOverlayModel => ({
+  width: frame.width,
+  height: frame.height,
+  points: LANDMARK_NAMES.map((name) => ({
+    name,
+    x: frame.landmarks[name].x * frame.width,
+    y: frame.landmarks[name].y * frame.height
+  })),
+  connections: [...LANDMARK_CONNECTIONS]
+});

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -161,6 +161,8 @@ const videoReadyForBitmap = (video: HTMLVideoElement): boolean =>
   video.videoWidth > 0 &&
   video.videoHeight > 0;
 
+type LaneDetection = FrontHandDetection | SideHandDetection | undefined;
+
 export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   let inspectionState = createInitialInspectionState();
   let activeTracking: ActiveTracking | undefined;
@@ -246,7 +248,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     tracker: MediaPipeHandTracker,
     options: LaneTrackingOptions,
     timestamp: FrameTimestamp
-  ): Promise<void> => {
+  ): Promise<LaneDetection> => {
     const bitmap = await createImageBitmap(options.video);
 
     try {
@@ -254,14 +256,12 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
         bitmap,
         timestamp.frameTimestampMs
       );
-      const laneDetection =
-        detection === undefined
-          ? undefined
-          : options.role === "frontAim"
-            ? toFrontDetection(detection, options, timestamp)
-            : toSideDetection(detection, options, timestamp);
 
-      setLaneDetection(options.role, laneDetection);
+      return detection === undefined
+        ? undefined
+        : options.role === "frontAim"
+          ? toFrontDetection(detection, options, timestamp)
+          : toSideDetection(detection, options, timestamp);
     } finally {
       bitmap.close();
     }
@@ -305,14 +305,23 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
           return;
         }
 
-        await runLaneDetection(tracker, options, timestamp);
+        const laneDetection = await runLaneDetection(
+          tracker,
+          options,
+          timestamp
+        );
 
         if (isStopped()) {
           return;
         }
 
+        setLaneDetection(options.role, laneDetection);
         setLaneHealth(options.role, "tracking");
       } catch (error: unknown) {
+        if (isStopped()) {
+          return;
+        }
+
         console.error("Diagnostic lane tracking failed", error);
         setLaneHealth(options.role, "failed");
         return;

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -31,7 +31,7 @@ interface LaneTrackingOptions {
   readonly streamId: string;
 }
 
-export interface LiveLandmarkInspection {
+interface LiveLandmarkInspection {
   getState(): WorkbenchInspectionState;
   sync(state: WorkbenchState): void;
   updateDom(): void;

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -17,6 +17,7 @@ import type {
 import type { WorkbenchState } from "./DiagnosticWorkbench";
 import { createLandmarkOverlayModel } from "./landmarkOverlay";
 import type { WorkbenchInspectionState } from "./renderWorkbench";
+import { formatFrameTimestamp } from "./timestampFormat";
 
 interface FrameTimingLike {
   readonly captureTime?: number;
@@ -38,6 +39,13 @@ interface LiveLandmarkInspection {
   destroy(): void;
 }
 
+interface ActiveTracking {
+  readonly key: string;
+  readonly frontVideo: HTMLVideoElement;
+  readonly sideVideo: HTMLVideoElement;
+  stop(): void;
+}
+
 const createInitialInspectionState = (): WorkbenchInspectionState => ({
   frontDetection: undefined,
   sideDetection: undefined,
@@ -50,34 +58,6 @@ const getFilterConfig = () => ({
   beta: gameConfig.input.handFilterBeta,
   dCutoff: gameConfig.input.handFilterDCutoff
 });
-
-const timestampSourceLabel = (
-  source: FrameTimestamp["timestampSource"]
-): string => {
-  switch (source) {
-    case "requestVideoFrameCallbackCaptureTime":
-      return "captureTime";
-    case "requestVideoFrameCallbackExpectedDisplayTime":
-      return "expectedDisplayTime";
-    case "performanceNowAtCallback":
-      return "performance.now";
-  }
-};
-
-const formatTimestamp = (timestamp: FrameTimestamp | undefined): string => {
-  if (timestamp === undefined) {
-    return "timestamp: 未取得";
-  }
-
-  const presentedFrames =
-    timestamp.presentedFrames === undefined
-      ? "presentedFrames: unavailable"
-      : `presentedFrames: ${String(timestamp.presentedFrames)}`;
-
-  return `${timestamp.frameTimestampMs.toFixed(1)} ms / ${timestampSourceLabel(
-    timestamp.timestampSource
-  )} / ${presentedFrames}`;
-};
 
 const updateText = (id: string, value: string): void => {
   const element = document.querySelector<HTMLElement>(`#${id}`);
@@ -156,6 +136,7 @@ const toFrontDetection = (
   rawFrame: detection.rawFrame,
   filteredFrame: detection.filteredFrame,
   handPresenceConfidence: handPresenceConfidenceFor(detection),
+  // TODO(M5): Compute real front tracking quality when front aim lands.
   trackingQuality: "good"
 });
 
@@ -171,6 +152,7 @@ const toSideDetection = (
   rawFrame: detection.rawFrame,
   filteredFrame: detection.filteredFrame,
   handPresenceConfidence: handPresenceConfidenceFor(detection),
+  // TODO(M4): Compute real side view quality when side trigger lands.
   sideViewQuality: "good"
 });
 
@@ -181,7 +163,7 @@ const videoReadyForBitmap = (video: HTMLVideoElement): boolean =>
 
 export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   let inspectionState = createInitialInspectionState();
-  let activeTracking: { readonly key: string; stop(): void } | undefined;
+  let activeTracking: ActiveTracking | undefined;
 
   const setInspection = (patch: Partial<WorkbenchInspectionState>): void => {
     inspectionState = { ...inspectionState, ...patch };
@@ -193,14 +175,14 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     updateText("wb-side-health", `health: ${inspectionState.sideLaneHealth}`);
     updateText(
       "wb-front-timestamp",
-      formatTimestamp(
+      formatFrameTimestamp(
         inspectionState.frontDetection?.timestamp ??
           inspectionState.frontFrameTimestamp
       )
     );
     updateText(
       "wb-side-timestamp",
-      formatTimestamp(
+      formatFrameTimestamp(
         inspectionState.sideDetection?.timestamp ??
           inspectionState.sideFrameTimestamp
       )
@@ -289,6 +271,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     options: LaneTrackingOptions
   ): { stop(): void } => {
     let stopped = false;
+    let cleanupStarted = false;
     let callbackId: number | undefined;
     let timeoutId: number | undefined;
     let trackerPromise: Promise<MediaPipeHandTracker> | undefined;
@@ -300,8 +283,10 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       return trackerPromise;
     };
 
+    const isStopped = (): boolean => stopped;
+
     const processFrame = async (metadata: FrameTimingLike): Promise<void> => {
-      if (stopped) {
+      if (isStopped()) {
         return;
       }
 
@@ -315,7 +300,17 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
       try {
         const tracker = await getTracker();
+
+        if (isStopped()) {
+          return;
+        }
+
         await runLaneDetection(tracker, options, timestamp);
+
+        if (isStopped()) {
+          return;
+        }
+
         setLaneHealth(options.role, "tracking");
       } catch (error: unknown) {
         console.error("Diagnostic lane tracking failed", error);
@@ -345,6 +340,19 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       }, 66);
     };
 
+    const cleanupTracker = (): void => {
+      if (cleanupStarted || trackerPromise === undefined) {
+        return;
+      }
+
+      cleanupStarted = true;
+      void trackerPromise
+        .then((tracker) => tracker.cleanup())
+        .catch((error: unknown) => {
+          console.error("Diagnostic lane tracker cleanup failed", error);
+        });
+    };
+
     schedule();
 
     return {
@@ -361,6 +369,8 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
         if (timeoutId !== undefined) {
           window.clearTimeout(timeoutId);
         }
+
+        cleanupTracker();
       }
     };
   };
@@ -397,7 +407,11 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
     const key = `${state.frontStream.stream.id}:${state.sideStream.stream.id}`;
 
-    if (activeTracking?.key === key) {
+    if (
+      activeTracking?.key === key &&
+      activeTracking.frontVideo === frontVideo &&
+      activeTracking.sideVideo === sideVideo
+    ) {
       return;
     }
 
@@ -419,6 +433,8 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
     activeTracking = {
       key,
+      frontVideo,
+      sideVideo,
       stop() {
         frontLane.stop();
         sideLane.stop();

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -1,0 +1,439 @@
+import { createFrameTimestamp } from "../camera/frameTimestamp";
+import {
+  createMediaPipeHandTracker,
+  type MediaPipeHandTracker
+} from "../hand-tracking/createMediaPipeHandTracker";
+import { gameConfig } from "../../shared/config/gameConfig";
+import type {
+  FrameTimestamp,
+  LaneHealthStatus
+} from "../../shared/types/camera";
+import type {
+  FrontHandDetection,
+  HandDetection,
+  HandFrame,
+  SideHandDetection
+} from "../../shared/types/hand";
+import type { WorkbenchState } from "./DiagnosticWorkbench";
+import { createLandmarkOverlayModel } from "./landmarkOverlay";
+import type { WorkbenchInspectionState } from "./renderWorkbench";
+
+interface FrameTimingLike {
+  readonly captureTime?: number;
+  readonly expectedDisplayTime?: number;
+  readonly presentedFrames?: number;
+}
+
+interface LaneTrackingOptions {
+  readonly role: "frontAim" | "sideTrigger";
+  readonly video: HTMLVideoElement;
+  readonly deviceId: string;
+  readonly streamId: string;
+}
+
+export interface LiveLandmarkInspection {
+  getState(): WorkbenchInspectionState;
+  sync(state: WorkbenchState): void;
+  updateDom(): void;
+  destroy(): void;
+}
+
+const createInitialInspectionState = (): WorkbenchInspectionState => ({
+  frontDetection: undefined,
+  sideDetection: undefined,
+  frontLaneHealth: "notStarted",
+  sideLaneHealth: "notStarted"
+});
+
+const getFilterConfig = () => ({
+  minCutoff: gameConfig.input.handFilterMinCutoff,
+  beta: gameConfig.input.handFilterBeta,
+  dCutoff: gameConfig.input.handFilterDCutoff
+});
+
+const timestampSourceLabel = (
+  source: FrameTimestamp["timestampSource"]
+): string => {
+  switch (source) {
+    case "requestVideoFrameCallbackCaptureTime":
+      return "captureTime";
+    case "requestVideoFrameCallbackExpectedDisplayTime":
+      return "expectedDisplayTime";
+    case "performanceNowAtCallback":
+      return "performance.now";
+  }
+};
+
+const formatTimestamp = (timestamp: FrameTimestamp | undefined): string => {
+  if (timestamp === undefined) {
+    return "timestamp: 未取得";
+  }
+
+  const presentedFrames =
+    timestamp.presentedFrames === undefined
+      ? "presentedFrames: unavailable"
+      : `presentedFrames: ${String(timestamp.presentedFrames)}`;
+
+  return `${timestamp.frameTimestampMs.toFixed(1)} ms / ${timestampSourceLabel(
+    timestamp.timestampSource
+  )} / ${presentedFrames}`;
+};
+
+const updateText = (id: string, value: string): void => {
+  const element = document.querySelector<HTMLElement>(`#${id}`);
+
+  if (element !== null) {
+    element.textContent = value;
+  }
+};
+
+const drawOverlay = (
+  canvasId: string,
+  frame: HandFrame | undefined,
+  color: string
+): void => {
+  const canvas = document.querySelector<HTMLCanvasElement>(`#${canvasId}`);
+
+  if (canvas === null) {
+    return;
+  }
+
+  const context = canvas.getContext("2d");
+
+  if (context === null) {
+    return;
+  }
+
+  if (frame === undefined) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    return;
+  }
+
+  const model = createLandmarkOverlayModel(frame);
+  canvas.width = model.width;
+  canvas.height = model.height;
+  context.clearRect(0, 0, model.width, model.height);
+  context.strokeStyle = color;
+  context.fillStyle = color;
+  context.lineWidth = 3;
+
+  for (const connection of model.connections) {
+    const from = model.points.find((point) => point.name === connection.from);
+    const to = model.points.find((point) => point.name === connection.to);
+
+    if (from === undefined || to === undefined) {
+      continue;
+    }
+
+    context.beginPath();
+    context.moveTo(from.x, from.y);
+    context.lineTo(to.x, to.y);
+    context.stroke();
+  }
+
+  for (const point of model.points) {
+    context.beginPath();
+    context.arc(point.x, point.y, 5, 0, Math.PI * 2);
+    context.fill();
+  }
+};
+
+const handPresenceConfidenceFor = (detection: HandDetection): number => {
+  const scores = detection.rawFrame.handedness?.map((hand) => hand.score) ?? [];
+
+  return scores.length === 0 ? 1 : Math.max(...scores);
+};
+
+const toFrontDetection = (
+  detection: HandDetection,
+  options: LaneTrackingOptions,
+  timestamp: FrameTimestamp
+): FrontHandDetection => ({
+  laneRole: "frontAim",
+  deviceId: options.deviceId,
+  streamId: options.streamId,
+  timestamp,
+  rawFrame: detection.rawFrame,
+  filteredFrame: detection.filteredFrame,
+  handPresenceConfidence: handPresenceConfidenceFor(detection),
+  trackingQuality: "good"
+});
+
+const toSideDetection = (
+  detection: HandDetection,
+  options: LaneTrackingOptions,
+  timestamp: FrameTimestamp
+): SideHandDetection => ({
+  laneRole: "sideTrigger",
+  deviceId: options.deviceId,
+  streamId: options.streamId,
+  timestamp,
+  rawFrame: detection.rawFrame,
+  filteredFrame: detection.filteredFrame,
+  handPresenceConfidence: handPresenceConfidenceFor(detection),
+  sideViewQuality: "good"
+});
+
+const videoReadyForBitmap = (video: HTMLVideoElement): boolean =>
+  video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA &&
+  video.videoWidth > 0 &&
+  video.videoHeight > 0;
+
+export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
+  let inspectionState = createInitialInspectionState();
+  let activeTracking: { readonly key: string; stop(): void } | undefined;
+
+  const setInspection = (patch: Partial<WorkbenchInspectionState>): void => {
+    inspectionState = { ...inspectionState, ...patch };
+    updateDom();
+  };
+
+  const updateDom = (): void => {
+    updateText("wb-front-health", `health: ${inspectionState.frontLaneHealth}`);
+    updateText("wb-side-health", `health: ${inspectionState.sideLaneHealth}`);
+    updateText(
+      "wb-front-timestamp",
+      formatTimestamp(
+        inspectionState.frontDetection?.timestamp ??
+          inspectionState.frontFrameTimestamp
+      )
+    );
+    updateText(
+      "wb-side-timestamp",
+      formatTimestamp(
+        inspectionState.sideDetection?.timestamp ??
+          inspectionState.sideFrameTimestamp
+      )
+    );
+    drawOverlay(
+      "wb-front-raw-overlay",
+      inspectionState.frontDetection?.rawFrame,
+      "#ff5a5f"
+    );
+    drawOverlay(
+      "wb-front-filtered-overlay",
+      inspectionState.frontDetection?.filteredFrame,
+      "#34d399"
+    );
+    drawOverlay(
+      "wb-side-raw-overlay",
+      inspectionState.sideDetection?.rawFrame,
+      "#ff5a5f"
+    );
+    drawOverlay(
+      "wb-side-filtered-overlay",
+      inspectionState.sideDetection?.filteredFrame,
+      "#34d399"
+    );
+  };
+
+  const setLaneHealth = (
+    role: LaneTrackingOptions["role"],
+    health: LaneHealthStatus
+  ): void => {
+    setInspection(
+      role === "frontAim"
+        ? { frontLaneHealth: health }
+        : { sideLaneHealth: health }
+    );
+  };
+
+  const setLaneTimestamp = (
+    role: LaneTrackingOptions["role"],
+    timestamp: FrameTimestamp
+  ): void => {
+    setInspection(
+      role === "frontAim"
+        ? { frontFrameTimestamp: timestamp }
+        : { sideFrameTimestamp: timestamp }
+    );
+  };
+
+  const setLaneDetection = (
+    role: LaneTrackingOptions["role"],
+    detection: FrontHandDetection | SideHandDetection | undefined
+  ): void => {
+    setInspection(
+      role === "frontAim"
+        ? { frontDetection: detection as FrontHandDetection | undefined }
+        : { sideDetection: detection as SideHandDetection | undefined }
+    );
+  };
+
+  const runLaneDetection = async (
+    tracker: MediaPipeHandTracker,
+    options: LaneTrackingOptions,
+    timestamp: FrameTimestamp
+  ): Promise<void> => {
+    const bitmap = await createImageBitmap(options.video);
+
+    try {
+      const detection = await tracker.detect(
+        bitmap,
+        timestamp.frameTimestampMs
+      );
+      const laneDetection =
+        detection === undefined
+          ? undefined
+          : options.role === "frontAim"
+            ? toFrontDetection(detection, options, timestamp)
+            : toSideDetection(detection, options, timestamp);
+
+      setLaneDetection(options.role, laneDetection);
+    } finally {
+      bitmap.close();
+    }
+  };
+
+  const startLaneTracking = (
+    options: LaneTrackingOptions
+  ): { stop(): void } => {
+    let stopped = false;
+    let callbackId: number | undefined;
+    let timeoutId: number | undefined;
+    let trackerPromise: Promise<MediaPipeHandTracker> | undefined;
+
+    setLaneHealth(options.role, "capturing");
+
+    const getTracker = (): Promise<MediaPipeHandTracker> => {
+      trackerPromise ??= createMediaPipeHandTracker({ getFilterConfig });
+      return trackerPromise;
+    };
+
+    const processFrame = async (metadata: FrameTimingLike): Promise<void> => {
+      if (stopped) {
+        return;
+      }
+
+      const timestamp = createFrameTimestamp(metadata, performance.now());
+      setLaneTimestamp(options.role, timestamp);
+
+      if (!videoReadyForBitmap(options.video)) {
+        schedule();
+        return;
+      }
+
+      try {
+        const tracker = await getTracker();
+        await runLaneDetection(tracker, options, timestamp);
+        setLaneHealth(options.role, "tracking");
+      } catch (error: unknown) {
+        console.error("Diagnostic lane tracking failed", error);
+        setLaneHealth(options.role, "failed");
+        return;
+      }
+
+      schedule();
+    };
+
+    const schedule = (): void => {
+      if (stopped) {
+        return;
+      }
+
+      if (typeof options.video.requestVideoFrameCallback === "function") {
+        callbackId = options.video.requestVideoFrameCallback(
+          (_now, metadata) => {
+            void processFrame(metadata);
+          }
+        );
+        return;
+      }
+
+      timeoutId = window.setTimeout(() => {
+        void processFrame({ expectedDisplayTime: performance.now() });
+      }, 66);
+    };
+
+    schedule();
+
+    return {
+      stop() {
+        stopped = true;
+
+        if (
+          callbackId !== undefined &&
+          typeof options.video.cancelVideoFrameCallback === "function"
+        ) {
+          options.video.cancelVideoFrameCallback(callbackId);
+        }
+
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId);
+        }
+      }
+    };
+  };
+
+  const resetTrackingState = (): void => {
+    inspectionState = createInitialInspectionState();
+    updateDom();
+  };
+
+  const stopActiveTracking = (): void => {
+    activeTracking?.stop();
+    activeTracking = undefined;
+  };
+
+  const sync = (state: WorkbenchState): void => {
+    if (
+      state.screen !== "previewing" ||
+      state.frontStream === undefined ||
+      state.sideStream === undefined
+    ) {
+      stopActiveTracking();
+      resetTrackingState();
+      return;
+    }
+
+    const frontVideo =
+      document.querySelector<HTMLVideoElement>("#wb-front-video");
+    const sideVideo =
+      document.querySelector<HTMLVideoElement>("#wb-side-video");
+
+    if (frontVideo === null || sideVideo === null) {
+      return;
+    }
+
+    const key = `${state.frontStream.stream.id}:${state.sideStream.stream.id}`;
+
+    if (activeTracking?.key === key) {
+      return;
+    }
+
+    stopActiveTracking();
+    resetTrackingState();
+
+    const frontLane = startLaneTracking({
+      role: "frontAim",
+      video: frontVideo,
+      deviceId: state.frontStream.deviceId,
+      streamId: state.frontStream.stream.id
+    });
+    const sideLane = startLaneTracking({
+      role: "sideTrigger",
+      video: sideVideo,
+      deviceId: state.sideStream.deviceId,
+      streamId: state.sideStream.stream.id
+    });
+
+    activeTracking = {
+      key,
+      stop() {
+        frontLane.stop();
+        sideLane.stop();
+      }
+    };
+  };
+
+  return {
+    getState() {
+      return inspectionState;
+    },
+    sync,
+    updateDom,
+    destroy() {
+      stopActiveTracking();
+    }
+  };
+};

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -2,13 +2,13 @@ import type { WorkbenchError, WorkbenchState } from "./DiagnosticWorkbench";
 import { escapeHTML } from "../../shared/browser/escapeHTML";
 import type {
   FrameTimestamp,
-  LaneHealthStatus,
-  TimestampSource
+  LaneHealthStatus
 } from "../../shared/types/camera";
 import type {
   FrontHandDetection,
   SideHandDetection
 } from "../../shared/types/hand";
+import { formatFrameTimestamp } from "./timestampFormat";
 
 export interface WorkbenchInspectionState {
   readonly frontDetection: FrontHandDetection | undefined;
@@ -115,38 +115,6 @@ const defaultInspectionState: WorkbenchInspectionState = {
   sideLaneHealth: "capturing"
 };
 
-const timestampSourceLabel = (source: TimestampSource): string => {
-  switch (source) {
-    case "requestVideoFrameCallbackCaptureTime":
-      return "captureTime";
-    case "requestVideoFrameCallbackExpectedDisplayTime":
-      return "expectedDisplayTime";
-    case "performanceNowAtCallback":
-      return "performance.now";
-  }
-};
-
-const formatFrameTimestamp = (
-  timestamp: FrameTimestamp | undefined
-): string => {
-  if (timestamp === undefined) {
-    return "timestamp: 未取得";
-  }
-
-  const presentedFrames =
-    timestamp.presentedFrames === undefined
-      ? "presentedFrames: unavailable"
-      : `presentedFrames: ${String(timestamp.presentedFrames)}`;
-
-  return [
-    `${timestamp.frameTimestampMs.toFixed(1)} ms`,
-    timestampSourceLabel(timestamp.timestampSource),
-    presentedFrames
-  ]
-    .map(escapeHTML)
-    .join(" / ");
-};
-
 const renderInspectionPane = (
   lanePrefix: "front" | "side",
   kind: "raw" | "filtered"
@@ -179,7 +147,7 @@ const renderInspectionLane = (
     <h3>${title}</h3>
     <p class="wb-device-label">${escapeHTML(deviceLabel)}</p>
     <p id="wb-${lanePrefix}-health" class="wb-lane-health">health: ${escapeHTML(health)}</p>
-    <p id="wb-${lanePrefix}-timestamp" class="wb-timestamp-readout">${formatFrameTimestamp(timestamp)}</p>
+    <p id="wb-${lanePrefix}-timestamp" class="wb-timestamp-readout">${escapeHTML(formatFrameTimestamp(timestamp))}</p>
     <div class="wb-inspection-panes">
       ${renderInspectionPane(lanePrefix, "raw")}
       ${renderInspectionPane(lanePrefix, "filtered")}

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -1,5 +1,23 @@
 import type { WorkbenchError, WorkbenchState } from "./DiagnosticWorkbench";
 import { escapeHTML } from "../../shared/browser/escapeHTML";
+import type {
+  FrameTimestamp,
+  LaneHealthStatus,
+  TimestampSource
+} from "../../shared/types/camera";
+import type {
+  FrontHandDetection,
+  SideHandDetection
+} from "../../shared/types/hand";
+
+export interface WorkbenchInspectionState {
+  readonly frontDetection: FrontHandDetection | undefined;
+  readonly sideDetection: SideHandDetection | undefined;
+  readonly frontFrameTimestamp?: FrameTimestamp;
+  readonly sideFrameTimestamp?: FrameTimestamp;
+  readonly frontLaneHealth: LaneHealthStatus;
+  readonly sideLaneHealth: LaneHealthStatus;
+}
 
 const renderPermissionScreen = (): string => `
   <div class="wb-screen">
@@ -82,9 +100,7 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
       <label>
         サイド（トリガー）:
         <select id="wb-side-select">
-          ${state.devices
-            .map((d, i) => renderDeviceOption(d, i))
-            .join("")}
+          ${state.devices.map((d, i) => renderDeviceOption(d, i)).join("")}
         </select>
       </label>
     </div>
@@ -92,21 +108,107 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
   </div>
 `;
 
-const renderPreviewing = (state: WorkbenchState): string => `
+const defaultInspectionState: WorkbenchInspectionState = {
+  frontDetection: undefined,
+  sideDetection: undefined,
+  frontLaneHealth: "capturing",
+  sideLaneHealth: "capturing"
+};
+
+const timestampSourceLabel = (source: TimestampSource): string => {
+  switch (source) {
+    case "requestVideoFrameCallbackCaptureTime":
+      return "captureTime";
+    case "requestVideoFrameCallbackExpectedDisplayTime":
+      return "expectedDisplayTime";
+    case "performanceNowAtCallback":
+      return "performance.now";
+  }
+};
+
+const formatFrameTimestamp = (
+  timestamp: FrameTimestamp | undefined
+): string => {
+  if (timestamp === undefined) {
+    return "timestamp: 未取得";
+  }
+
+  const presentedFrames =
+    timestamp.presentedFrames === undefined
+      ? "presentedFrames: unavailable"
+      : `presentedFrames: ${String(timestamp.presentedFrames)}`;
+
+  return [
+    `${timestamp.frameTimestampMs.toFixed(1)} ms`,
+    timestampSourceLabel(timestamp.timestampSource),
+    presentedFrames
+  ]
+    .map(escapeHTML)
+    .join(" / ");
+};
+
+const renderInspectionPane = (
+  lanePrefix: "front" | "side",
+  kind: "raw" | "filtered"
+): string => {
+  const label = kind === "raw" ? "生ランドマーク" : "フィルタ後ランドマーク";
+  const videoId =
+    kind === "raw"
+      ? `wb-${lanePrefix}-video`
+      : `wb-${lanePrefix}-${kind}-video`;
+
+  return `
+    <div class="wb-inspection-pane">
+      <h4>${label}</h4>
+      <div class="wb-video-stack">
+        <video id="${videoId}" autoplay playsinline muted></video>
+        <canvas id="wb-${lanePrefix}-${kind}-overlay" class="wb-landmark-overlay"></canvas>
+      </div>
+    </div>
+  `;
+};
+
+const renderInspectionLane = (
+  lanePrefix: "front" | "side",
+  title: string,
+  deviceLabel: string,
+  health: LaneHealthStatus,
+  timestamp: FrameTimestamp | undefined
+): string => `
+  <section class="wb-preview-lane wb-inspection-lane">
+    <h3>${title}</h3>
+    <p class="wb-device-label">${escapeHTML(deviceLabel)}</p>
+    <p id="wb-${lanePrefix}-health" class="wb-lane-health">health: ${escapeHTML(health)}</p>
+    <p id="wb-${lanePrefix}-timestamp" class="wb-timestamp-readout">${formatFrameTimestamp(timestamp)}</p>
+    <div class="wb-inspection-panes">
+      ${renderInspectionPane(lanePrefix, "raw")}
+      ${renderInspectionPane(lanePrefix, "filtered")}
+    </div>
+  </section>
+`;
+
+const renderPreviewing = (
+  state: WorkbenchState,
+  inspection: WorkbenchInspectionState
+): string => `
   <div class="wb-previewing">
     <h2>ライブプレビュー</h2>
     ${renderInlineError(state.error)}
     <div class="wb-preview-grid">
-      <div class="wb-preview-lane">
-        <h3>フロント（照準）</h3>
-        <p class="wb-device-label">${escapeHTML(state.frontAssignment?.label ?? "未選択")}</p>
-        <video id="wb-front-video" autoplay playsinline muted></video>
-      </div>
-      <div class="wb-preview-lane">
-        <h3>サイド（トリガー）</h3>
-        <p class="wb-device-label">${escapeHTML(state.sideAssignment?.label ?? "未選択")}</p>
-        <video id="wb-side-video" autoplay playsinline muted></video>
-      </div>
+      ${renderInspectionLane(
+        "front",
+        "フロント（照準）",
+        state.frontAssignment?.label ?? "未選択",
+        inspection.frontLaneHealth,
+        inspection.frontDetection?.timestamp ?? inspection.frontFrameTimestamp
+      )}
+      ${renderInspectionLane(
+        "side",
+        "サイド（トリガー）",
+        state.sideAssignment?.label ?? "未選択",
+        inspection.sideLaneHealth,
+        inspection.sideDetection?.timestamp ?? inspection.sideFrameTimestamp
+      )}
     </div>
     <div class="wb-controls">
       <button class="wb-btn" data-wb-action="swap">左右入れ替え</button>
@@ -115,7 +217,10 @@ const renderPreviewing = (state: WorkbenchState): string => `
   </div>
 `;
 
-export const renderWorkbenchHTML = (state: WorkbenchState): string => {
+export const renderWorkbenchHTML = (
+  state: WorkbenchState,
+  inspection: WorkbenchInspectionState = defaultInspectionState
+): string => {
   switch (state.screen) {
     case "permission":
       return renderPermissionScreen();
@@ -132,6 +237,6 @@ export const renderWorkbenchHTML = (state: WorkbenchState): string => {
     case "deviceSelection":
       return renderDeviceSelection(state);
     case "previewing":
-      return renderPreviewing(state);
+      return renderPreviewing(state, inspection);
   }
 };

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -111,8 +111,8 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
 const defaultInspectionState: WorkbenchInspectionState = {
   frontDetection: undefined,
   sideDetection: undefined,
-  frontLaneHealth: "capturing",
-  sideLaneHealth: "capturing"
+  frontLaneHealth: "notStarted",
+  sideLaneHealth: "notStarted"
 };
 
 const renderInspectionPane = (

--- a/src/features/diagnostic-workbench/timestampFormat.ts
+++ b/src/features/diagnostic-workbench/timestampFormat.ts
@@ -1,0 +1,34 @@
+import type {
+  FrameTimestamp,
+  TimestampSource
+} from "../../shared/types/camera";
+
+export const timestampSourceLabel = (source: TimestampSource): string => {
+  switch (source) {
+    case "requestVideoFrameCallbackCaptureTime":
+      return "captureTime";
+    case "requestVideoFrameCallbackExpectedDisplayTime":
+      return "expectedDisplayTime";
+    case "performanceNowAtCallback":
+      return "performance.now";
+  }
+};
+
+export const formatFrameTimestamp = (
+  timestamp: FrameTimestamp | undefined
+): string => {
+  if (timestamp === undefined) {
+    return "timestamp: 未取得";
+  }
+
+  const presentedFrames =
+    timestamp.presentedFrames === undefined
+      ? "presentedFrames: unavailable"
+      : `presentedFrames: ${String(timestamp.presentedFrames)}`;
+
+  return [
+    `${timestamp.frameTimestampMs.toFixed(1)} ms`,
+    timestampSourceLabel(timestamp.timestampSource),
+    presentedFrames
+  ].join(" / ");
+};

--- a/src/features/hand-tracking/createMediaPipeHandTracker.ts
+++ b/src/features/hand-tracking/createMediaPipeHandTracker.ts
@@ -35,7 +35,7 @@ export interface MediaPipeHandTracker {
   ): Promise<HandDetection | undefined>;
 }
 
-export interface MediaPipeHandTrackerOptions {
+interface MediaPipeHandTrackerOptions {
   getFilterConfig: () => OneEuroFilterConfig;
 }
 

--- a/src/features/hand-tracking/createMediaPipeHandTracker.ts
+++ b/src/features/hand-tracking/createMediaPipeHandTracker.ts
@@ -33,6 +33,7 @@ export interface MediaPipeHandTracker {
     bitmap: ImageBitmap,
     frameAtMs: number
   ): Promise<HandDetection | undefined>;
+  cleanup(): Promise<void> | void;
 }
 
 interface MediaPipeHandTrackerOptions {
@@ -301,13 +302,14 @@ export const createMediaPipeHandTracker = async (
   options: MediaPipeHandTrackerOptions
 ): Promise<MediaPipeHandTracker> => {
   const vision = await FilesetResolver.forVisionTasks(MEDIAPIPE_WASM_URL);
-  const handLandmarker = await HandLandmarker.createFromOptions(vision, {
-    baseOptions: {
-      modelAssetPath: "/models/hand_landmarker.task"
-    },
-    numHands: 1,
-    runningMode: "VIDEO"
-  });
+  let handLandmarker: HandLandmarker | undefined =
+    await HandLandmarker.createFromOptions(vision, {
+      baseOptions: {
+        modelAssetPath: "/models/hand_landmarker.task"
+      },
+      numHands: 1,
+      runningMode: "VIDEO"
+    });
   const filters = createSpaceFilters(options.getFilterConfig);
 
   return {
@@ -315,6 +317,10 @@ export const createMediaPipeHandTracker = async (
       bitmap: ImageBitmap,
       frameAtMs: number
     ): Promise<HandDetection | undefined> {
+      if (handLandmarker === undefined) {
+        throw new Error("MediaPipe hand tracker has already been cleaned up.");
+      }
+
       const raw = toHandFrame(
         handLandmarker.detectForVideo(bitmap, frameAtMs),
         {
@@ -331,6 +337,11 @@ export const createMediaPipeHandTracker = async (
       const filtered = filterHandFrame(raw, filters, frameAtMs);
 
       return Promise.resolve({ rawFrame: raw, filteredFrame: filtered });
+    },
+
+    cleanup() {
+      handLandmarker?.close();
+      handLandmarker = undefined;
     }
   };
 };

--- a/src/features/hand-tracking/createMediaPipeHandTracker.ts
+++ b/src/features/hand-tracking/createMediaPipeHandTracker.ts
@@ -28,14 +28,14 @@ interface HandLandmarkerResultLike {
   handednesses?: HandednessLike[][];
 }
 
-interface MediaPipeHandTracker {
+export interface MediaPipeHandTracker {
   detect(
     bitmap: ImageBitmap,
     frameAtMs: number
   ): Promise<HandDetection | undefined>;
 }
 
-interface MediaPipeHandTrackerOptions {
+export interface MediaPipeHandTrackerOptions {
   getFilterConfig: () => OneEuroFilterConfig;
 }
 
@@ -118,7 +118,6 @@ const filterPoint = (
   z: filters.z.filter(point.z, frameAtMs)
 });
 
-
 // Keep this helper thin: filter timestamp must be supplied at call-site.
 const filterHandFrame = (
   raw: HandFrame,
@@ -128,18 +127,50 @@ const filterHandFrame = (
   ...raw,
   landmarks: {
     wrist: filterPoint(raw.landmarks.wrist, filters.image.wrist, frameAtMs),
-    thumbIp: filterPoint(raw.landmarks.thumbIp, filters.image.thumbIp, frameAtMs),
-    thumbTip: filterPoint(raw.landmarks.thumbTip, filters.image.thumbTip, frameAtMs),
-    indexMcp: filterPoint(raw.landmarks.indexMcp, filters.image.indexMcp, frameAtMs),
-    indexTip: filterPoint(raw.landmarks.indexTip, filters.image.indexTip, frameAtMs),
-    middleTip: filterPoint(raw.landmarks.middleTip, filters.image.middleTip, frameAtMs),
-    ringTip: filterPoint(raw.landmarks.ringTip, filters.image.ringTip, frameAtMs),
-    pinkyTip: filterPoint(raw.landmarks.pinkyTip, filters.image.pinkyTip, frameAtMs)
+    thumbIp: filterPoint(
+      raw.landmarks.thumbIp,
+      filters.image.thumbIp,
+      frameAtMs
+    ),
+    thumbTip: filterPoint(
+      raw.landmarks.thumbTip,
+      filters.image.thumbTip,
+      frameAtMs
+    ),
+    indexMcp: filterPoint(
+      raw.landmarks.indexMcp,
+      filters.image.indexMcp,
+      frameAtMs
+    ),
+    indexTip: filterPoint(
+      raw.landmarks.indexTip,
+      filters.image.indexTip,
+      frameAtMs
+    ),
+    middleTip: filterPoint(
+      raw.landmarks.middleTip,
+      filters.image.middleTip,
+      frameAtMs
+    ),
+    ringTip: filterPoint(
+      raw.landmarks.ringTip,
+      filters.image.ringTip,
+      frameAtMs
+    ),
+    pinkyTip: filterPoint(
+      raw.landmarks.pinkyTip,
+      filters.image.pinkyTip,
+      frameAtMs
+    )
   },
   ...(raw.worldLandmarks
     ? {
         worldLandmarks: {
-          wrist: filterPoint(raw.worldLandmarks.wrist, filters.world.wrist, frameAtMs),
+          wrist: filterPoint(
+            raw.worldLandmarks.wrist,
+            filters.world.wrist,
+            frameAtMs
+          ),
           thumbIp: filterPoint(
             raw.worldLandmarks.thumbIp,
             filters.world.thumbIp,

--- a/src/shared/types/camera.ts
+++ b/src/shared/types/camera.ts
@@ -3,3 +3,25 @@
  * Logs, telemetry, and errors use this to identify the failing role.
  */
 export type CameraLaneRole = "frontAim" | "sideTrigger";
+
+export type TimestampSource =
+  | "requestVideoFrameCallbackCaptureTime"
+  | "requestVideoFrameCallbackExpectedDisplayTime"
+  | "performanceNowAtCallback";
+
+export interface FrameTimestamp {
+  readonly frameTimestampMs: number;
+  readonly timestampSource: TimestampSource;
+  readonly presentedFrames: number | undefined;
+  readonly receivedAtPerformanceMs: number;
+}
+
+export type LaneHealthStatus =
+  | "notStarted"
+  | "waitingForPermission"
+  | "waitingForDeviceSelection"
+  | "capturing"
+  | "tracking"
+  | "stalled"
+  | "captureLost"
+  | "failed";

--- a/src/shared/types/hand.ts
+++ b/src/shared/types/hand.ts
@@ -1,3 +1,5 @@
+import type { CameraLaneRole, FrameTimestamp } from "./camera";
+
 export interface Point3D {
   x: number;
   y: number;
@@ -49,4 +51,22 @@ export interface HandFrame {
 export interface HandDetection {
   rawFrame: HandFrame;
   filteredFrame: HandFrame;
+}
+
+interface LaneHandDetectionBase extends HandDetection {
+  readonly laneRole: CameraLaneRole;
+  readonly deviceId: string;
+  readonly streamId: string;
+  readonly timestamp: FrameTimestamp;
+  readonly handPresenceConfidence: number;
+}
+
+export interface FrontHandDetection extends LaneHandDetectionBase {
+  readonly laneRole: "frontAim";
+  readonly trackingQuality: "good" | "uncertain" | "lost";
+}
+
+export interface SideHandDetection extends LaneHandDetectionBase {
+  readonly laneRole: "sideTrigger";
+  readonly sideViewQuality: "good" | "frontLike" | "tooOccluded" | "lost";
 }

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -13,7 +13,7 @@ body {
 }
 
 #diagnostic-app {
-  max-width: 960px;
+  max-width: 1280px;
   margin: 0 auto;
   padding: 1rem;
 }
@@ -28,6 +28,12 @@ h3 {
   font-size: 1rem;
   margin-bottom: 0.5rem;
   color: #a8d8ea;
+}
+
+h4 {
+  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+  color: #d7f4ff;
 }
 
 .wb-screen {
@@ -117,16 +123,59 @@ h3 {
   padding: 0.75rem;
 }
 
+.wb-inspection-lane {
+  text-align: left;
+}
+
 .wb-preview-lane video {
   width: 100%;
   border-radius: 4px;
   background: #000;
 }
 
+.wb-inspection-panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.wb-inspection-pane {
+  min-width: 0;
+}
+
+.wb-video-stack {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #000;
+}
+
+.wb-video-stack video {
+  display: block;
+  width: 100%;
+}
+
+.wb-landmark-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
 .wb-device-label {
   font-size: 0.8rem;
   color: #888;
   margin-bottom: 0.5rem;
+}
+
+.wb-lane-health,
+.wb-timestamp-readout {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: #c9d4dc;
+  margin-bottom: 0.4rem;
 }
 
 .wb-controls {
@@ -140,4 +189,11 @@ h3 {
   margin: 1rem 0;
   background: rgba(231, 76, 60, 0.1);
   text-align: left;
+}
+
+@media (max-width: 780px) {
+  .wb-preview-grid,
+  .wb-inspection-panes {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -171,7 +171,7 @@ h4 {
 
 .wb-lane-health,
 .wb-timestamp-readout {
-  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
   font-size: 0.78rem;
   line-height: 1.4;
   color: #c9d4dc;

--- a/tests/e2e/diagnostic.smoke.spec.ts
+++ b/tests/e2e/diagnostic.smoke.spec.ts
@@ -59,21 +59,41 @@ test("diagnostic workbench runs permission, device selection, previews, swap, an
   await page.locator("#wb-side-select").selectOption("side-device-id");
   await page.getByRole("button", { name: "確定" }).click();
 
-  await expect(page.getByRole("heading", { name: "ライブプレビュー" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "ライブプレビュー" })
+  ).toBeVisible();
   await expect(page.locator("#wb-front-video")).toBeVisible();
   await expect(page.locator("#wb-side-video")).toBeVisible();
-  await expect(page.locator(".wb-preview-lane").first()).toContainText("Front Camera");
-  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText("Side Camera");
+  await expect(page.locator("#wb-front-raw-overlay")).toBeVisible();
+  await expect(page.locator("#wb-front-filtered-overlay")).toBeVisible();
+  await expect(page.locator("#wb-side-raw-overlay")).toBeVisible();
+  await expect(page.locator("#wb-side-filtered-overlay")).toBeVisible();
+  await expect(page.getByText("生ランドマーク").first()).toBeVisible();
+  await expect(page.getByText("フィルタ後ランドマーク").first()).toBeVisible();
+  await expect(page.locator("#wb-front-timestamp")).toContainText("timestamp");
+  await expect(page.locator("#wb-side-timestamp")).toContainText("timestamp");
+  await expect(page.locator(".wb-preview-lane").first()).toContainText(
+    "Front Camera"
+  );
+  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText(
+    "Side Camera"
+  );
 
   await page.getByRole("button", { name: "左右入れ替え" }).click();
-  await expect(page.locator(".wb-preview-lane").first()).toContainText("Side Camera");
-  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText("Front Camera");
+  await expect(page.locator(".wb-preview-lane").first()).toContainText(
+    "Side Camera"
+  );
+  await expect(page.locator(".wb-preview-lane").nth(1)).toContainText(
+    "Front Camera"
+  );
 
   await page.getByRole("button", { name: "再選択" }).click();
   await expect(page.getByRole("heading", { name: "カメラ選択" })).toBeVisible();
 });
 
-test("diagnostic workbench shows permission denial details", async ({ page }) => {
+test("diagnostic workbench shows permission denial details", async ({
+  page
+}) => {
   await installFakeCameras(
     page,
     [{ deviceId: "front-device-id", label: "Front Camera" }],
@@ -83,14 +103,18 @@ test("diagnostic workbench shows permission denial details", async ({ page }) =>
   await page.goto("/diagnostic.html");
   await page.getByRole("button", { name: "カメラ許可" }).click();
 
-  await expect(page.getByRole("heading", { name: "カメラ許可が拒否されました" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "カメラ許可が拒否されました" })
+  ).toBeVisible();
   await expect(page.getByText("原因:")).toBeVisible();
   await expect(page.getByText("影響:")).toBeVisible();
   await expect(page.getByText("再現:")).toBeVisible();
   await expect(page.getByText("対処:")).toBeVisible();
 });
 
-test("diagnostic workbench warns when only one camera is available", async ({ page }) => {
+test("diagnostic workbench warns when only one camera is available", async ({
+  page
+}) => {
   await installFakeCameras(page, [
     { deviceId: "front-device-id", label: "Front Camera" }
   ]);
@@ -98,8 +122,12 @@ test("diagnostic workbench warns when only one camera is available", async ({ pa
   await page.goto("/diagnostic.html");
   await page.getByRole("button", { name: "カメラ許可" }).click();
 
-  await expect(page.getByRole("heading", { name: "カメラが1台しか検出されません" })).toBeVisible();
   await expect(
-    page.getByText("1台のカメラをフロントとサイドの両方に再利用することはできません")
+    page.getByRole("heading", { name: "カメラが1台しか検出されません" })
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "1台のカメラをフロントとサイドの両方に再利用することはできません"
+    )
   ).toBeVisible();
 });

--- a/tests/unit/features/camera/frameTimestamp.test.ts
+++ b/tests/unit/features/camera/frameTimestamp.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { createFrameTimestamp } from "../../../../src/features/camera/frameTimestamp";
+
+describe("createFrameTimestamp", () => {
+  it("prefers requestVideoFrameCallback captureTime when available", () => {
+    const timestamp = createFrameTimestamp(
+      {
+        captureTime: 1234.5,
+        expectedDisplayTime: 2345.6,
+        presentedFrames: 42
+      },
+      3456.7
+    );
+
+    expect(timestamp).toStrictEqual({
+      frameTimestampMs: 1234.5,
+      timestampSource: "requestVideoFrameCallbackCaptureTime",
+      presentedFrames: 42,
+      receivedAtPerformanceMs: 3456.7
+    });
+  });
+
+  it("falls back to expectedDisplayTime when captureTime is unavailable", () => {
+    const timestamp = createFrameTimestamp(
+      {
+        expectedDisplayTime: 2345.6,
+        presentedFrames: 42
+      },
+      3456.7
+    );
+
+    expect(timestamp).toStrictEqual({
+      frameTimestampMs: 2345.6,
+      timestampSource: "requestVideoFrameCallbackExpectedDisplayTime",
+      presentedFrames: 42,
+      receivedAtPerformanceMs: 3456.7
+    });
+  });
+
+  it("uses callback receipt time when browser frame metadata has no usable timing", () => {
+    const timestamp = createFrameTimestamp({}, 3456.7);
+
+    expect(timestamp).toStrictEqual({
+      frameTimestampMs: 3456.7,
+      timestampSource: "performanceNowAtCallback",
+      presentedFrames: undefined,
+      receivedAtPerformanceMs: 3456.7
+    });
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/landmarkOverlay.test.ts
+++ b/tests/unit/features/diagnostic-workbench/landmarkOverlay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { HandFrame } from "../../../../src/shared/types/hand";
+import { createLandmarkOverlayModel } from "../../../../src/features/diagnostic-workbench/landmarkOverlay";
+
+const createFrame = (): HandFrame => ({
+  width: 640,
+  height: 480,
+  landmarks: {
+    wrist: { x: 0.1, y: 0.2, z: 0 },
+    thumbIp: { x: 0.2, y: 0.3, z: 0 },
+    thumbTip: { x: 0.3, y: 0.4, z: 0 },
+    indexMcp: { x: 0.4, y: 0.5, z: 0 },
+    indexTip: { x: 0.5, y: 0.6, z: 0 },
+    middleTip: { x: 0.6, y: 0.7, z: 0 },
+    ringTip: { x: 0.7, y: 0.8, z: 0 },
+    pinkyTip: { x: 0.8, y: 0.9, z: 0 }
+  }
+});
+
+describe("createLandmarkOverlayModel", () => {
+  it("projects normalized landmarks to source-frame pixels", () => {
+    const model = createLandmarkOverlayModel(createFrame());
+
+    expect(model.width).toBe(640);
+    expect(model.height).toBe(480);
+    expect(
+      model.points.find((point) => point.name === "indexTip")
+    ).toStrictEqual({
+      name: "indexTip",
+      x: 320,
+      y: 288
+    });
+  });
+
+  it("keeps named landmark connections for overlay drawing", () => {
+    const model = createLandmarkOverlayModel(createFrame());
+
+    expect(model.connections).toContainEqual({
+      from: "wrist",
+      to: "indexMcp"
+    });
+    expect(model.connections).toContainEqual({
+      from: "indexMcp",
+      to: "indexTip"
+    });
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -136,6 +136,30 @@ const createFakeTracker = (): FakeTracker => ({
   cleanup: vi.fn()
 });
 
+const createHandFrame = () => ({
+  width: 640,
+  height: 480,
+  landmarks: {
+    wrist: { x: 0.1, y: 0.2, z: 0 },
+    thumbIp: { x: 0.2, y: 0.3, z: 0 },
+    thumbTip: { x: 0.3, y: 0.4, z: 0 },
+    indexMcp: { x: 0.4, y: 0.5, z: 0 },
+    indexTip: { x: 0.5, y: 0.6, z: 0 },
+    middleTip: { x: 0.6, y: 0.7, z: 0 },
+    ringTip: { x: 0.7, y: 0.8, z: 0 },
+    pinkyTip: { x: 0.8, y: 0.9, z: 0 }
+  }
+});
+
+const createHandDetection = () => {
+  const frame = createHandFrame();
+
+  return {
+    rawFrame: frame,
+    filteredFrame: frame
+  };
+};
+
 const createDeferred = <T>() => {
   let resolve!: (value: T) => void;
   let reject!: (reason: unknown) => void;
@@ -368,5 +392,42 @@ describe("createLiveLandmarkInspection", () => {
     });
     expect(frontTracker.detect).not.toHaveBeenCalled();
     expect(sideTracker.detect).not.toHaveBeenCalled();
+  });
+
+  it("does not write stale detection results after stop while detect is in flight", async () => {
+    const frontTracker = createFakeTracker();
+    const detectResult = createDeferred<ReturnType<typeof createHandDetection>>();
+    const bitmapClose = vi.fn();
+    frontTracker.detect.mockReturnValueOnce(detectResult.promise);
+    vi.mocked(createImageBitmap).mockResolvedValueOnce({
+      width: 640,
+      height: 480,
+      close: bitmapClose
+    } as ImageBitmap);
+    createMediaPipeHandTrackerMock.mockResolvedValueOnce(frontTracker);
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    });
+    videos.frontVideo.fireFrame();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.detect).toHaveBeenCalledOnce();
+    });
+    liveInspection.destroy();
+    detectResult.resolve(createHandDetection());
+
+    await vi.waitFor(() => {
+      expect(bitmapClose).toHaveBeenCalledOnce();
+    });
+    expect(liveInspection.getState().frontDetection).toBeUndefined();
   });
 });

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requestCameraPermission } from "../../../../src/features/camera/cameraPermission";
+import { createDevicePinnedStream } from "../../../../src/features/camera/createDevicePinnedStream";
+import type { DevicePinnedStream } from "../../../../src/features/camera/createDevicePinnedStream";
+import { enumerateVideoDevices } from "../../../../src/features/camera/enumerateVideoDevices";
+import { createDiagnosticWorkbench } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
+import type { DiagnosticWorkbench } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
+import { createLiveLandmarkInspection } from "../../../../src/features/diagnostic-workbench/liveLandmarkInspection";
+import { renderWorkbenchHTML } from "../../../../src/features/diagnostic-workbench/renderWorkbench";
+
+const { createMediaPipeHandTrackerMock } = vi.hoisted(() => ({
+  createMediaPipeHandTrackerMock: vi.fn()
+}));
+
+vi.mock("../../../../src/features/camera/cameraPermission", () => ({
+  requestCameraPermission: vi.fn()
+}));
+
+vi.mock("../../../../src/features/camera/enumerateVideoDevices", () => ({
+  enumerateVideoDevices: vi.fn()
+}));
+
+vi.mock("../../../../src/features/camera/createDevicePinnedStream", () => ({
+  createDevicePinnedStream: vi.fn()
+}));
+
+vi.mock(
+  "../../../../src/features/hand-tracking/createMediaPipeHandTracker",
+  () => ({
+    createMediaPipeHandTracker: createMediaPipeHandTrackerMock
+  })
+);
+
+interface FakeTextElement {
+  textContent: string;
+}
+
+interface FakeCanvas {
+  width: number;
+  height: number;
+  getContext: ReturnType<typeof vi.fn>;
+}
+
+interface FakeVideo {
+  readonly id: string;
+  srcObject: MediaStream | undefined;
+  readyState: number;
+  videoWidth: number;
+  videoHeight: number;
+  requestVideoFrameCallback: ReturnType<typeof vi.fn>;
+  cancelVideoFrameCallback: ReturnType<typeof vi.fn>;
+  fireFrame(metadata?: {
+    captureTime?: number;
+    expectedDisplayTime?: number;
+    presentedFrames?: number;
+  }): void;
+}
+
+type VideoFrameCallbackLike = (
+  now: number,
+  metadata: {
+    captureTime?: number;
+    expectedDisplayTime?: number;
+    presentedFrames?: number;
+  }
+) => void;
+
+interface FakeTracker {
+  detect: ReturnType<typeof vi.fn>;
+  cleanup: ReturnType<typeof vi.fn>;
+}
+
+const elements = new Map<string, unknown>();
+
+const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
+  ({
+    kind: "videoinput",
+    deviceId,
+    label,
+    groupId: `${deviceId}-group`,
+    toJSON: () => ({})
+  }) as MediaDeviceInfo;
+
+const createPinnedStream = (deviceId: string): DevicePinnedStream => ({
+  stream: { id: `${deviceId}-stream` } as MediaStream,
+  deviceId,
+  stop: vi.fn()
+});
+
+const createCameraError = (name: string): Error =>
+  Object.assign(new Error(name), { name });
+
+const createFakeTextElement = (): FakeTextElement => ({ textContent: "" });
+
+const createFakeCanvas = (): FakeCanvas => ({
+  width: 0,
+  height: 0,
+  getContext: vi.fn(() => null)
+});
+
+const createFakeVideo = (id: string): FakeVideo => {
+  const callbacks = new Map<number, VideoFrameCallbackLike>();
+  let nextCallbackId = 1;
+
+  return {
+    id,
+    srcObject: undefined,
+    readyState: 2,
+    videoWidth: 640,
+    videoHeight: 480,
+    requestVideoFrameCallback: vi.fn((callback: VideoFrameCallbackLike) => {
+      const id = nextCallbackId;
+      nextCallbackId += 1;
+      callbacks.set(id, callback);
+      return id;
+    }),
+    cancelVideoFrameCallback: vi.fn((id: number) => {
+      callbacks.delete(id);
+    }),
+    fireFrame(metadata = { captureTime: 123, presentedFrames: 1 }) {
+      const next = callbacks.entries().next().value;
+
+      if (next === undefined) {
+        throw new Error("No pending video frame callback");
+      }
+
+      const [callbackId, callback] = next;
+      callbacks.delete(callbackId);
+      callback(1000, metadata);
+    }
+  };
+};
+
+const createFakeTracker = (): FakeTracker => ({
+  detect: vi.fn(() => Promise.resolve(undefined)),
+  cleanup: vi.fn()
+});
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
+const installBaseDom = (): void => {
+  elements.clear();
+
+  for (const id of [
+    "#wb-front-health",
+    "#wb-side-health",
+    "#wb-front-timestamp",
+    "#wb-side-timestamp"
+  ]) {
+    elements.set(id, createFakeTextElement());
+  }
+
+  for (const id of [
+    "#wb-front-raw-overlay",
+    "#wb-front-filtered-overlay",
+    "#wb-side-raw-overlay",
+    "#wb-side-filtered-overlay"
+  ]) {
+    elements.set(id, createFakeCanvas());
+  }
+
+  vi.stubGlobal("document", {
+    querySelector: vi.fn((selector: string) => elements.get(selector) ?? null)
+  });
+  vi.stubGlobal("window", {
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout
+  });
+  vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });
+  vi.stubGlobal(
+    "createImageBitmap",
+    vi.fn(() =>
+      Promise.resolve({
+        width: 640,
+        height: 480,
+        close: vi.fn()
+      })
+    )
+  );
+};
+
+const installPreviewVideos = (): {
+  frontVideo: FakeVideo;
+  frontFilteredVideo: FakeVideo;
+  sideVideo: FakeVideo;
+  sideFilteredVideo: FakeVideo;
+} => {
+  const frontVideo = createFakeVideo("wb-front-video");
+  const frontFilteredVideo = createFakeVideo("wb-front-filtered-video");
+  const sideVideo = createFakeVideo("wb-side-video");
+  const sideFilteredVideo = createFakeVideo("wb-side-filtered-video");
+
+  elements.set("#wb-front-video", frontVideo);
+  elements.set("#wb-front-filtered-video", frontFilteredVideo);
+  elements.set("#wb-side-video", sideVideo);
+  elements.set("#wb-side-filtered-video", sideFilteredVideo);
+
+  return {
+    frontVideo,
+    frontFilteredVideo,
+    sideVideo,
+    sideFilteredVideo
+  };
+};
+
+const attachVideoStreams = (
+  workbench: DiagnosticWorkbench,
+  videos: ReturnType<typeof installPreviewVideos>
+): void => {
+  const state = workbench.getState();
+
+  videos.frontVideo.srcObject = state.frontStream?.stream;
+  videos.frontFilteredVideo.srcObject = state.frontStream?.stream;
+  videos.sideVideo.srcObject = state.sideStream?.stream;
+  videos.sideFilteredVideo.srcObject = state.sideStream?.stream;
+};
+
+describe("createLiveLandmarkInspection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installBaseDom();
+    vi.mocked(requestCameraPermission).mockResolvedValue({ status: "granted" });
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("front-id", "Front Camera"),
+      createDevice("side-id", "Side Camera")
+    ]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("restarts tracking when a preserve-preview swap failure re-renders fresh video elements", async () => {
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    const attemptedSwapStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream)
+      .mockResolvedValueOnce(attemptedSwapStream)
+      .mockRejectedValueOnce(createCameraError("OverconstrainedError"));
+    const workbench = createDiagnosticWorkbench();
+    const liveInspection = createLiveLandmarkInspection();
+    let currentVideos: ReturnType<typeof installPreviewVideos> | undefined;
+    const render = (): void => {
+      const state = workbench.getState();
+      renderWorkbenchHTML(state, liveInspection.getState());
+
+      if (state.screen === "previewing") {
+        currentVideos = installPreviewVideos();
+        attachVideoStreams(workbench, currentVideos);
+      }
+
+      liveInspection.sync(state);
+      liveInspection.updateDom();
+    };
+
+    workbench.subscribe(render);
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+
+    const initialVideos = currentVideos;
+    expect(initialVideos).toBeDefined();
+    if (initialVideos === undefined) {
+      throw new Error("preview videos should be installed");
+    }
+    expect(
+      initialVideos.frontVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+    expect(
+      initialVideos.sideVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+
+    await workbench.swapRoles();
+
+    const rerenderedVideos = currentVideos;
+    expect(rerenderedVideos).toBeDefined();
+    if (rerenderedVideos === undefined) {
+      throw new Error("rerendered preview videos should be installed");
+    }
+    expect(rerenderedVideos.frontVideo).not.toBe(initialVideos.frontVideo);
+    expect(rerenderedVideos.sideVideo).not.toBe(initialVideos.sideVideo);
+    expect(
+      initialVideos.frontVideo.cancelVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+    expect(
+      initialVideos.sideVideo.cancelVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+    expect(
+      rerenderedVideos.frontVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+    expect(
+      rerenderedVideos.sideVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up MediaPipe trackers when live tracking stops", async () => {
+    const frontTracker = createFakeTracker();
+    const sideTracker = createFakeTracker();
+    createMediaPipeHandTrackerMock
+      .mockResolvedValueOnce(frontTracker)
+      .mockResolvedValueOnce(sideTracker);
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    });
+    videos.frontVideo.fireFrame();
+    videos.sideVideo.fireFrame();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.detect).toHaveBeenCalledOnce();
+      expect(sideTracker.detect).toHaveBeenCalledOnce();
+    });
+    liveInspection.destroy();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.cleanup).toHaveBeenCalledOnce();
+      expect(sideTracker.cleanup).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not run detection after stop while tracker startup is pending", async () => {
+    const frontTracker = createFakeTracker();
+    const sideTracker = createFakeTracker();
+    const frontTrackerStartup = createDeferred<FakeTracker>();
+    const sideTrackerStartup = createDeferred<FakeTracker>();
+    createMediaPipeHandTrackerMock
+      .mockReturnValueOnce(frontTrackerStartup.promise)
+      .mockReturnValueOnce(sideTrackerStartup.promise);
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    });
+    videos.frontVideo.fireFrame();
+    videos.sideVideo.fireFrame();
+    liveInspection.destroy();
+    frontTrackerStartup.resolve(frontTracker);
+    sideTrackerStartup.resolve(sideTracker);
+
+    await vi.waitFor(() => {
+      expect(frontTracker.cleanup).toHaveBeenCalledOnce();
+      expect(sideTracker.cleanup).toHaveBeenCalledOnce();
+    });
+    expect(frontTracker.detect).not.toHaveBeenCalled();
+    expect(sideTracker.detect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -5,6 +5,11 @@ import type {
   WorkbenchState
 } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
 import { renderWorkbenchHTML } from "../../../../src/features/diagnostic-workbench/renderWorkbench";
+import type {
+  FrontHandDetection,
+  HandFrame,
+  SideHandDetection
+} from "../../../../src/shared/types/hand";
 
 const createState = (patch: Partial<WorkbenchState>): WorkbenchState => ({
   screen: "permission",
@@ -34,6 +39,53 @@ const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
     groupId: `${deviceId}-group`,
     toJSON: () => ({})
   }) as MediaDeviceInfo;
+
+const createHandFrame = (offset: number): HandFrame => ({
+  width: 640,
+  height: 480,
+  landmarks: {
+    wrist: { x: 0.1 + offset, y: 0.2, z: 0 },
+    thumbIp: { x: 0.2 + offset, y: 0.3, z: 0 },
+    thumbTip: { x: 0.3 + offset, y: 0.4, z: 0 },
+    indexMcp: { x: 0.4 + offset, y: 0.5, z: 0 },
+    indexTip: { x: 0.5 + offset, y: 0.6, z: 0 },
+    middleTip: { x: 0.6 + offset, y: 0.7, z: 0 },
+    ringTip: { x: 0.7 + offset, y: 0.8, z: 0 },
+    pinkyTip: { x: 0.8 + offset, y: 0.9, z: 0 }
+  }
+});
+
+const createFrontDetection = (): FrontHandDetection => ({
+  laneRole: "frontAim",
+  deviceId: "front-secret-device-id",
+  streamId: "front-stream",
+  timestamp: {
+    frameTimestampMs: 1234.5,
+    timestampSource: "requestVideoFrameCallbackCaptureTime",
+    presentedFrames: 7,
+    receivedAtPerformanceMs: 1250
+  },
+  rawFrame: createHandFrame(0),
+  filteredFrame: createHandFrame(0.01),
+  handPresenceConfidence: 0.97,
+  trackingQuality: "good"
+});
+
+const createSideDetection = (): SideHandDetection => ({
+  laneRole: "sideTrigger",
+  deviceId: "side-secret-device-id",
+  streamId: "side-stream",
+  timestamp: {
+    frameTimestampMs: 1240,
+    timestampSource: "requestVideoFrameCallbackExpectedDisplayTime",
+    presentedFrames: 8,
+    receivedAtPerformanceMs: 1255
+  },
+  rawFrame: createHandFrame(0.02),
+  filteredFrame: createHandFrame(0.03),
+  handPresenceConfidence: 0.88,
+  sideViewQuality: "good"
+});
 
 describe("renderWorkbenchHTML", () => {
   it("renders the permission screen", () => {
@@ -89,7 +141,9 @@ describe("renderWorkbenchHTML", () => {
     const html = renderWorkbenchHTML(createState({ screen: "singleCamera" }));
 
     expect(html).toContain("カメラが1台しか検出されません");
-    expect(html).toContain("1台のカメラをフロントとサイドの両方に再利用することはできません");
+    expect(html).toContain(
+      "1台のカメラをフロントとサイドの両方に再利用することはできません"
+    );
   });
 
   it("escapes device labels and ids in device selection", () => {
@@ -132,5 +186,40 @@ describe("renderWorkbenchHTML", () => {
     expect(html).toContain("Side &lt;Camera&gt;");
     expect(html).not.toContain(rawFrontId.slice(0, 8));
     expect(html).not.toContain(rawSideId.slice(0, 8));
+  });
+
+  it("renders raw and filtered landmark inspection panes with timestamp readouts", () => {
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "previewing",
+        frontAssignment: {
+          role: "frontAim",
+          deviceId: "front-secret-device-id",
+          label: "Front Camera"
+        },
+        sideAssignment: {
+          role: "sideTrigger",
+          deviceId: "side-secret-device-id",
+          label: "Side Camera"
+        }
+      }),
+      {
+        frontDetection: createFrontDetection(),
+        sideDetection: createSideDetection(),
+        frontLaneHealth: "tracking",
+        sideLaneHealth: "tracking"
+      }
+    );
+
+    expect(html).toContain("生ランドマーク");
+    expect(html).toContain("フィルタ後ランドマーク");
+    expect(html).toContain('id="wb-front-raw-overlay"');
+    expect(html).toContain('id="wb-front-filtered-overlay"');
+    expect(html).toContain('id="wb-side-raw-overlay"');
+    expect(html).toContain('id="wb-side-filtered-overlay"');
+    expect(html).toContain("1234.5 ms");
+    expect(html).toContain("captureTime");
+    expect(html).toContain("1240.0 ms");
+    expect(html).toContain("expectedDisplayTime");
   });
 });

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -4,6 +4,7 @@ import type {
   WorkbenchScreen,
   WorkbenchState
 } from "../../../../src/features/diagnostic-workbench/DiagnosticWorkbench";
+import { createLiveLandmarkInspection } from "../../../../src/features/diagnostic-workbench/liveLandmarkInspection";
 import { renderWorkbenchHTML } from "../../../../src/features/diagnostic-workbench/renderWorkbench";
 import type {
   FrontHandDetection,
@@ -186,6 +187,28 @@ describe("renderWorkbenchHTML", () => {
     expect(html).toContain("Side &lt;Camera&gt;");
     expect(html).not.toContain(rawFrontId.slice(0, 8));
     expect(html).not.toContain(rawSideId.slice(0, 8));
+  });
+
+  it("uses initial inspection health values when preview inspection is omitted", () => {
+    const initialInspection = createLiveLandmarkInspection().getState();
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "previewing",
+        frontAssignment: {
+          role: "frontAim",
+          deviceId: "front-id",
+          label: "Front Camera"
+        },
+        sideAssignment: {
+          role: "sideTrigger",
+          deviceId: "side-id",
+          label: "Side Camera"
+        }
+      })
+    );
+
+    expect(html).toContain(`health: ${initialInspection.frontLaneHealth}`);
+    expect(html).toContain(`health: ${initialInspection.sideLaneHealth}`);
   });
 
   it("renders raw and filtered landmark inspection panes with timestamp readouts", () => {

--- a/tests/unit/features/diagnostic-workbench/timestampFormat.test.ts
+++ b/tests/unit/features/diagnostic-workbench/timestampFormat.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatFrameTimestamp,
+  timestampSourceLabel
+} from "../../../../src/features/diagnostic-workbench/timestampFormat";
+
+describe("timestampFormat", () => {
+  it("labels requestVideoFrameCallback timestamp sources", () => {
+    expect(timestampSourceLabel("requestVideoFrameCallbackCaptureTime")).toBe(
+      "captureTime"
+    );
+    expect(
+      timestampSourceLabel("requestVideoFrameCallbackExpectedDisplayTime")
+    ).toBe("expectedDisplayTime");
+    expect(timestampSourceLabel("performanceNowAtCallback")).toBe(
+      "performance.now"
+    );
+  });
+
+  it("formats missing and present frame timestamps", () => {
+    expect(formatFrameTimestamp(undefined)).toBe("timestamp: 未取得");
+    expect(
+      formatFrameTimestamp({
+        frameTimestampMs: 1234.56,
+        timestampSource: "requestVideoFrameCallbackCaptureTime",
+        presentedFrames: 7,
+        receivedAtPerformanceMs: 1250
+      })
+    ).toBe("1234.6 ms / captureTime / presentedFrames: 7");
+    expect(
+      formatFrameTimestamp({
+        frameTimestampMs: 1240,
+        timestampSource: "requestVideoFrameCallbackExpectedDisplayTime",
+        presentedFrames: undefined,
+        receivedAtPerformanceMs: 1255
+      })
+    ).toBe("1240.0 ms / expectedDisplayTime / presentedFrames: unavailable");
+  });
+});

--- a/tests/unit/features/hand-tracking/createMediaPipeHandTracker.test.ts
+++ b/tests/unit/features/hand-tracking/createMediaPipeHandTracker.test.ts
@@ -37,16 +37,18 @@ const BASE_LANDMARKS_FRAME_2 = BASE_LANDMARKS_FRAME_1.map((landmark) => {
   return landmark;
 });
 
-const WORLD_LANDMARKS_FRAME_1: TestLandmark[] = BASE_LANDMARKS_FRAME_1.map((landmark) => {
-  if ("x" in landmark) {
-    return {
-      x: landmark.x + 0.1,
-      y: landmark.y + 0.1,
-      z: landmark.z + 0.1
-    };
+const WORLD_LANDMARKS_FRAME_1: TestLandmark[] = BASE_LANDMARKS_FRAME_1.map(
+  (landmark) => {
+    if ("x" in landmark) {
+      return {
+        x: landmark.x + 0.1,
+        y: landmark.y + 0.1,
+        z: landmark.z + 0.1
+      };
+    }
+    return landmark;
   }
-  return landmark;
-});
+);
 
 const WORLD_LANDMARKS_FRAME_2 = WORLD_LANDMARKS_FRAME_1.map((landmark) => {
   if ("x" in landmark) {
@@ -93,12 +95,13 @@ const createExpectedFrame = (
 });
 
 const { createFromOptions, forVisionTasks } = vi.hoisted(() => ({
-  createFromOptions: vi.fn(() =>
+  createFromOptions: vi.fn<() => Promise<unknown>>(() =>
     Promise.resolve({
-      detectForVideo: vi.fn(() => ({ landmarks: [BASE_LANDMARKS_FRAME_1] }))
+      detectForVideo: vi.fn(() => ({ landmarks: [BASE_LANDMARKS_FRAME_1] })),
+      close: vi.fn()
     })
   ),
-  forVisionTasks: vi.fn(() => Promise.resolve("vision"))
+  forVisionTasks: vi.fn<() => Promise<unknown>>(() => Promise.resolve("vision"))
 }));
 
 vi.mock("@mediapipe/tasks-vision", () => ({
@@ -125,12 +128,20 @@ const LANDMARK_NAMES = [
   "pinkyTip"
 ] as const;
 
-type HandLandmarkSet = Record<(typeof LANDMARK_NAMES)[number], { x: number; y: number; z: number }>;
+type HandLandmarkSet = Record<
+  (typeof LANDMARK_NAMES)[number],
+  { x: number; y: number; z: number }
+>;
 
 interface ExpectedFrame {
   width: number;
   height: number;
-  handedness?: { score: number; index: number; categoryName: string; displayName: string }[];
+  handedness?: {
+    score: number;
+    index: number;
+    categoryName: string;
+    displayName: string;
+  }[];
   landmarks: HandLandmarkSet;
   worldLandmarks?: HandLandmarkSet;
 }
@@ -361,6 +372,22 @@ describe("createMediaPipeHandTracker", () => {
     await expect(tracker.detect(bitmap, 0)).resolves.toBeUndefined();
   });
 
+  it("closes the underlying hand landmarker during cleanup", async () => {
+    const close = vi.fn();
+    createFromOptions.mockResolvedValueOnce({
+      detectForVideo: vi.fn(() => ({ landmarks: [] })),
+      close
+    });
+
+    const tracker = await createMediaPipeHandTracker({
+      getFilterConfig: PASS_THROUGH_CONFIG
+    });
+
+    await tracker.cleanup();
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
   it("smooths per-landmark x/y/z values on the filtered frame while keeping raw untouched", async () => {
     const detectForVideo = vi
       .fn()
@@ -396,7 +423,9 @@ describe("createMediaPipeHandTracker", () => {
 
     expect(first.filteredFrame.worldLandmarks?.indexTip.x).toBeCloseTo(0.6);
     expect(second.rawFrame.worldLandmarks?.indexTip.x).toBeCloseTo(0.7);
-    expect(second.filteredFrame.worldLandmarks?.indexTip.x).toBeGreaterThan(0.6);
+    expect(second.filteredFrame.worldLandmarks?.indexTip.x).toBeGreaterThan(
+      0.6
+    );
     expect(second.filteredFrame.worldLandmarks?.indexTip.x).toBeLessThan(0.61);
 
     expect(first.filteredFrame.worldLandmarks?.wrist.y).toBeCloseTo(0.3);


### PR DESCRIPTION
## Summary
- add minimal FrameTimestamp and lane health contracts plus FrontHandDetection/SideHandDetection shared shapes
- wire diagnostic.html to run front/side MediaPipe hand tracking and show raw + filtered landmark overlays with timestamp readouts
- keep landmark inspection isolated to diagnostic-workbench modules; game entry remains production-clean

## Tests
- npm run lint
- npm run typecheck
- npm run test
- npm run test:e2e

Closes #3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/balloonshoot_v2/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New features**
  * Added live hand-landmark inspection to the preview (front / side raw and filtered overlays, per-lane health display, formatted timestamp readout).
  * Added display logic that projects landmarks into frame coordinates.

* **Style**
  * Widened layout (960 → 1280px) and added new styles and responsive support for the inspection mode.

* **Chores**
  * Strengthened video binding during preview and added resource teardown on unload.

* **Tests**
  * Added and expanded numerous unit / E2E tests verifying display and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
