### PR TITLE
feat(M9): Live Trial Hardening

### DIFF
--- a/docs/superpowers/plans/2026-04-18-m9-implementation-decomposition.md
+++ b/docs/superpowers/plans/2026-04-18-m9-implementation-decomposition.md
@@ -1,0 +1,645 @@
+# M9: Live Trial Hardening 実装粒度タスク分解
+
+## 1. Pre-flight checks
+
+M9 は M8 完了後の `main` から開始する。開始前に次を確認する。
+
+- `git rev-parse HEAD` が post-M7 `1fa082a` 以降、かつ M8 が merge 済みであること。今回確認時点の HEAD は `1fa082a54ebc90f982f5c66bc705a43a4abd1c14`。
+- `gh issue view 9` が `M9: Live Trial Hardening` を指し、目的が「device 抜き差し / track 終了の可視化、再選択、degrade 明示」であること。
+- `src/shared/types/camera.ts` の実際の `LaneHealthStatus` は次の 8 variants:
+  - `notStarted`
+  - `waitingForPermission`
+  - `waitingForDeviceSelection`
+  - `capturing`
+  - `tracking`
+  - `stalled`
+  - `captureLost`
+  - `failed`
+- `src/features/input-fusion/createInputFusionMapper.ts` は既に `failed | stalled | captureLost` を `laneFailed` として扱う。M9 はこの contract を壊さず、`captureLost` に入った瞬間に `updateAimUnavailable()` / `updateTriggerUnavailable()` で stale buffer を掃除する。
+- 現状 `src/` に `onended` / `devicechange` handler は実装されていない。M9 は `MediaStreamTrack` の `ended` event と `navigator.mediaDevices.devicechange` を初めて配線する。
+- `src/features/camera/createDevicePinnedStream.ts` は `DevicePinnedStream` と `stop()` だけを返す。M9 では track ended listener を attach/detach できるよう、stream から tracks を読む helper を camera feature に置く。
+- `src/features/diagnostic-workbench/DiagnosticWorkbench.ts` は `requestGeneration` / `openGeneration` で async race を抑制している。M9 の device refresh / reselect はこの generation guard を再利用する。
+- `src/features/diagnostic-workbench/liveLandmarkInspection.ts` は lane health を持つが、track ended を検知しない。M9 では lane-local cleanup、fusion unavailable update、health `captureLost` をここに追加する。
+- `src/app/balloonGameRuntime.ts` は M7 R3 で round-3 lane resource release を持ち、`MAX_CONSECUTIVE_FRAME_ERRORS` 到達時に該当 lane の stream/tracker を解放する。M9 は track ended でも同じ lesson を再利用する。
+- `src/app/balloonGameRuntime.ts` の HUD degrade message は `fusionRejectReason === "laneFailed"` に対して現在 `"カメラが失敗しました。リトライしてください"` を表示する。M9 では source lane health が `captureLost` の場合だけ `"カメラが切断されました"` を優先表示する。
+- `src/app/balloonGamePage.ts` は start 前の device dropdown を持つが、running 中の devicechange / reselect UX はない。M9 は production-clean な再選択経路だけ追加する。
+- M8 coordination check:
+  - この作業ツリーでは `claude/m8-followup` ローカル branch は存在するが、tracked `src/tests/docs` diff は `1fa082a..claude/m8-followup` で空。
+  - `origin/claude/m8-followup` はこの checkout では存在しなかった。
+  - `docs/superpowers/plans/2026-04-18-m8-implementation-decomposition.md` は未追跡ファイルとして存在する。
+- M8 contradiction to resolve before implementation:
+  - M8 decomposition says workbench reselect resets calibration to defaults.
+  - M9 request says reconnecting the same lane should not reset session-scoped calibration.
+  - M9 implementation should not start until post-M8 `main` confirms the final calibration policy. Recommended M9 policy: preserve calibration across same-lane reconnect/reselect within the session; reset only on explicit calibration reset or role swap if the lane role changes.
+
+## 2. Numbered implementation steps
+
+### 1. Add a camera-track ended observer helper
+
+**Scope:** `~≤2h`
+
+**Files to create / modify**
+
+- Create: `src/features/camera/observeTrackEnded.ts`
+- Modify: `src/features/camera/AGENTS.md` only if a narrower lifecycle note is needed; likely no change.
+- Add tests: `tests/unit/features/camera/observeTrackEnded.test.ts`
+
+**Implementation notes**
+
+- Add a small camera-feature helper, not a new architecture layer.
+- API shape:
+  - `observeTrackEnded(stream, callback): { stop(): void }`
+  - attach to every `video` track from `stream.getVideoTracks()` when present; fallback to `stream.getTracks().filter(track.kind === "video")`.
+  - use `addEventListener("ended", handler)` / `removeEventListener("ended", handler)` instead of overwriting `track.onended`, so retry/reselect cannot clobber another listener.
+  - callback receives a compact payload:
+    - `trackId`
+    - `readyState`
+    - optional `label`
+- Make `stop()` idempotent.
+- Do not call `MediaStreamTrack.stop()` from this helper. It observes only.
+
+**Test plan**
+
+- Unit: fake `MediaStreamTrack` fires `ended` and invokes callback once.
+- Unit: `stop()` removes listeners and prevents later callback.
+- Unit: repeated `stop()` is safe.
+- Unit: multiple video tracks attach and detach independently.
+- Unit: non-video tracks are ignored.
+- Use key/value assertions for payload fields, not broad snapshot equality.
+
+**Dependencies on M3-M8 contracts**
+
+- M3/M7 stream lifecycle: stream ownership remains with workbench/runtime callers.
+- M6/M7 cleanup lesson: helper only reports track end; lane owner performs tracker/stream release.
+- M8: no calibration dependency.
+
+### 2. Convert track end into lane-local `captureLost` in the diagnostic live inspection
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/features/diagnostic-workbench/liveLandmarkInspection.ts`
+- Modify tests: `tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts`
+
+**Implementation notes**
+
+- Extend `LaneTrackingOptions` with the active `MediaStream`.
+- In `startLaneTracking()`, call `observeTrackEnded(options.stream, onTrackEnded)`.
+- On track end:
+  - guard with the existing `stopped` flag;
+  - set lane health to `captureLost`;
+  - cancel pending `requestVideoFrameCallback` / timeout;
+  - cleanup the lane tracker exactly once;
+  - clear lane detection/frame/telemetry snapshots for the affected lane;
+  - call `inputFusionMapper.updateAimUnavailable()` or `updateTriggerUnavailable()` with a fresh synthetic timestamp from `performance.now()`;
+  - keep the other lane running.
+- Do not leave `frontDetection` or `sideDetection` from the dead stream visible.
+- Do not reset side trigger tuning or fusion tuning.
+- If M8 is merged, do not reset same-lane calibration on track end.
+
+**Test plan**
+
+- Unit: fake front stream track ending sets `frontLaneHealth` to `captureLost`.
+- Unit: front track end clears front detection/aim telemetry and produces a fusion frame whose `frontSource.laneHealth` is `captureLost`.
+- Unit: side track end clears side trigger frame/telemetry, resets shot consumption via `updateTriggerUnavailable()`, and leaves front aim available if fresh.
+- Unit: tracker cleanup and video-frame callback cancellation happen once.
+- Unit: track end after `destroy()` is ignored.
+- Unit: retry/reselect after capture loss does not reuse stale snapshots.
+- Use fake `MediaStreamTrack` rather than trying to trigger real browser unplug behavior.
+
+**Dependencies on M3-M8 contracts**
+
+- M3: `liveLandmarkInspection.ts` owns per-frame tracker lifecycle.
+- M4: side trigger loss must not synthesize release or shot.
+- M5: front loss must go through unavailable aim semantics.
+- M6: use `updateAimUnavailable()` / `updateTriggerUnavailable()` to clear fusion buffers.
+- M8: preserve session-scoped calibration if final M8 policy says same-lane reconnect preserves it.
+
+### 3. Convert track end into lane-local `captureLost` in game runtime
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/app/balloonGameRuntime.ts`
+- Modify tests: `tests/integration/balloonGameRuntime.test.ts`
+
+**Implementation notes**
+
+- After `openStream(deviceId)` succeeds in `startLane()`, attach `observeTrackEnded(stream.stream, onTrackEnded)`.
+- Treat track end as a lane failure caused by capture loss, not a tracker failure:
+  - set the affected `frontLaneHealth` / `sideLaneHealth` to `captureLost`;
+  - call `updateUnavailable(timestamp)` immediately;
+  - call the existing lane resource release path;
+  - remove that lane’s stop function from `laneStops`;
+  - remove stream/tracker from arrays;
+  - cleanup tracker exactly once.
+- Keep the opposite lane running.
+- Do not auto-select another camera. M9 must not silently switch hardware.
+- Ensure manual `stopCameraTracking()`, `retry()`, and `destroy()` detach track-ended listeners before releasing streams.
+- Track end should not increment `consecutiveFrameErrors`; it is capture loss, not frame processing failure.
+
+**Test plan**
+
+- Integration: front track ended sets fusion context `frontLaneHealth: "captureLost"` and latest fused frame rejects with `laneFailed`.
+- Integration: side track ended sets `sideLaneHealth: "captureLost"` and no shot can fire after loss.
+- Integration: front track ended stops only front stream/tracker and leaves side stream/tracker active.
+- Integration: `retry()` after capture loss starts new front and side trackers once.
+- Integration: `destroy()` after capture loss does not double-stop streams or double-clean trackers.
+- Integration: duplicate ended events from the same fake track do not double cleanup.
+- Keep `toBe` for primitive health/reject-reason assertions.
+
+**Dependencies on M3-M8 contracts**
+
+- M6: fusion uses explicit lane health.
+- M7 R2/R3: retry and lane resource release are existing runtime seams.
+- M8: if runtime passes default calibration after M8, retry keeps default-only game calibration behavior.
+
+### 4. Add devicechange event wiring and refresh device lists without auto-opening streams
+
+**Scope:** `~≤2h`
+
+**Files to create / modify**
+
+- Create: `src/features/camera/observeDeviceChange.ts`
+- Modify: `src/features/diagnostic-workbench/DiagnosticWorkbench.ts`
+- Modify: `src/diagnostic-main.ts`
+- Modify tests:
+  - `tests/unit/features/camera/observeDeviceChange.test.ts`
+  - `tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts`
+  - `tests/e2e/diagnostic.smoke.spec.ts`
+
+**Implementation notes**
+
+- Add `observeDeviceChange(callback): { stop(): void }`.
+  - use `navigator.mediaDevices.addEventListener("devicechange", callback)` when available;
+  - fallback to preserving/restoring `navigator.mediaDevices.ondevicechange` if needed;
+  - idempotent cleanup.
+- Add a workbench method such as `refreshDevicesFromDeviceChange(): Promise<void>`.
+- Refresh behavior:
+  - if screen is `permission`, do nothing until permission is granted;
+  - if screen is `deviceSelection`, `singleCamera`, `cameraNotFound`, or `enumerationFailed`, re-enumerate and update screen based on count;
+  - if screen is `previewing`, re-enumerate `devices` and update labels/options, but do not stop active streams and do not auto-open replacements;
+  - if selected device disappears while previewing, keep preview screen and rely on `track ended -> captureLost` for lane health.
+- Use `requestGeneration` / `openGeneration` or a new `deviceRefreshGeneration` to prevent stale enumeration overwrites.
+- Do not spin up trackers from `devicechange`.
+
+**Test plan**
+
+- Unit: fake devicechange calls workbench refresh once.
+- Unit: selection screen updates from one camera to two cameras and moves from `singleCamera` to `deviceSelection`.
+- Unit: previewing devicechange updates `devices` but does not call `createDevicePinnedStream`.
+- Unit: older enumerate result resolving after a newer devicechange is ignored.
+- E2E: in `diagnostic.html`, fake `navigator.mediaDevices` dispatches `devicechange`; dropdown reflects new camera list after clicking reselect.
+- E2E should remain smoke-level; detailed race behavior stays in unit tests.
+
+**Dependencies on M3-M8 contracts**
+
+- M1/M3: permission precedes `enumerateDevices()`.
+- M3/M4: workbench owns device selection UX.
+- M8: calibration controls remain unchanged; devicechange is additive.
+
+### 5. Surface capture-lost health in diagnostic workbench UI
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/features/diagnostic-workbench/renderWorkbench.ts`
+- Modify: `src/features/diagnostic-workbench/liveLandmarkInspection.ts` if extra state is needed.
+- Modify tests:
+  - `tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts`
+  - `tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts`
+
+**Implementation notes**
+
+- Add a lane-health display helper inside diagnostic workbench, for example:
+  - `tracking -> "tracking"`
+  - `capturing -> "capturing"`
+  - `captureLost -> "カメラが切断されました"`
+  - `failed -> "カメラ処理に失敗しました"`
+  - `stalled -> "カメラ入力が停止しています"`
+- Keep raw health available in the text, but add user-facing Japanese for live trial operators.
+- In previewing state, keep the existing `再選択` button visible.
+- Do not add debug-only overlay to the game page.
+- Do not remove existing tuning/calibration controls.
+
+**Test plan**
+
+- Unit: `captureLost` renders `"カメラが切断されました"`.
+- Unit: health HTML escapes text and does not expose raw `deviceId`.
+- Unit: previewing with one lane `captureLost` still renders fusion panel and reselect button.
+- Unit: undefined telemetry fields still render `"unavailable"` in lane panels.
+
+**Dependencies on M3-M8 contracts**
+
+- M3: workbench observes lanes but does not own correctness.
+- M6: fusion telemetry remains visible during degraded states.
+- M8: calibration telemetry remains visible if available; no reset from render path.
+
+### 6. Make fusion loss entry explicit and lock `captureLost -> laneFailed` behavior
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `tests/unit/features/input-fusion/createInputFusionMapper.test.ts`
+- Modify: `tests/unit/features/input-fusion/typeContract.test.ts` only if coverage is missing.
+- Modify: `src/features/input-fusion/createInputFusionMapper.ts` only if tests expose a gap.
+
+**Implementation notes**
+
+- Current implementation already treats `captureLost` as failed via `isFailed()`.
+- Add regression tests so future refactors cannot drop this.
+- Tests should cover both:
+  - front health `captureLost` with latest side frame present;
+  - side health `captureLost` with latest front frame present.
+- Assert:
+  - `fusionRejectReason === "laneFailed"`;
+  - affected source `laneHealth === "captureLost"`;
+  - affected source `rejectReason === "laneFailed"`;
+  - `fusionMode` does not pair front/side while a lane is capture-lost.
+- Do not add a new `FusionRejectReason` for `captureLost`; M9 requirement says `LaneHealthStatus` reflects real device state, while fusion reject reason remains explicit and stable.
+
+**Test plan**
+
+- Unit: `updateAimUnavailable(timestamp, { frontLaneHealth: "captureLost" })` clears front buffer and returns `laneFailed`.
+- Unit: `updateTriggerUnavailable(timestamp, { sideLaneHealth: "captureLost" })` clears side buffer and resets shot consumption.
+- Replay: only update replay fixtures if existing replay assumptions break; expected no replay churn.
+
+**Dependencies on M3-M8 contracts**
+
+- M6 R5: unavailable lane updates are the buffer-clearing seam.
+- M7: gameplay consumes only `FusedGameInputFrame`.
+- M8: calibration metadata must not enter fusion frame shape.
+
+### 7. Add production-clean game HUD copy for `captureLost`
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/app/balloonGameRuntime.ts`
+- Modify: `src/app/gameHud.ts` only if an action button is added in step 8.
+- Modify tests:
+  - `tests/integration/balloonGameRuntime.test.ts`
+  - `tests/unit/app/gameHud.test.ts`
+
+**Implementation notes**
+
+- Keep game page production-clean.
+- Do not expose `fusionRejectReason`, raw lane health, device ids, timestamps, or debug terminology.
+- Update `statusMessageForFusedFrame()`:
+  - if `frame.fusionRejectReason === "laneFailed"` and either `frontSource.laneHealth` or `sideSource.laneHealth` is `captureLost`, return `"カメラが切断されました"`;
+  - otherwise keep existing generic lane failure copy.
+- Preserve existing messages for `frontMissing`, `sideMissing`, stale, and timestamp gap.
+- Do not add diagnostic panels or threshold text.
+
+**Test plan**
+
+- Unit/integration: fused frame with `frontSource.laneHealth: "captureLost"` renders `"カメラが切断されました"`.
+- Unit/integration: fused frame with `sideSource.laneHealth: "captureLost"` renders same concise message.
+- Unit: generic `failed` still renders `"カメラが失敗しました。リトライしてください"` or the post-M9 chosen generic copy.
+- Unit: game HUD output does not contain `captureLost`, `laneFailed`, or `fusionRejectReason`.
+- E2E home smoke: no diagnostic selectors or debug labels appear.
+
+**Dependencies on M3-M8 contracts**
+
+- M7 R3: HUD already reads fused degraded state.
+- M6: lane health is available through `frontSource` / `sideSource`.
+- M8: no calibration UI on game page.
+
+### 8. Add a game-page reselect path after capture loss
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/app/gameHud.ts`
+- Modify: `src/app/balloonGameRuntime.ts`
+- Modify: `src/app/balloonGamePage.ts`
+- Modify tests:
+  - `tests/unit/app/gameHud.test.ts`
+  - `tests/unit/app/balloonGamePage.test.ts`
+  - `tests/integration/balloonGameRuntime.test.ts`
+  - `tests/e2e/home.smoke.spec.ts`
+
+**Implementation notes**
+
+- Add a production-clean action, not a debug overlay.
+- Recommended UI:
+  - when status is capture-lost, show message `"カメラが切断されました"` and a small button `"カメラを選び直す"` with `data-game-action="reselectCameras"`.
+- `balloonGamePage.ts` should handle `reselectCameras`:
+  - destroy current runtime;
+  - re-enumerate video devices;
+  - return to the existing device selection screen;
+  - preserve previous `selectedFrontDeviceId` / `selectedSideDeviceId` if still present;
+  - if a selected id no longer exists, choose a valid remaining default and show a concise selection error such as `"切断されたカメラを選び直してください。"`
+- Starting from the dropdown should call existing `startRuntime(frontId, sideId)`, which creates a fresh runtime and restarts lane pipelines.
+- Do not silently switch cameras on devicechange.
+- Do not add one-camera fallback.
+
+**Test plan**
+
+- Unit: capture-lost HUD includes `"カメラを選び直す"` and no debug text.
+- Unit: clicking `reselectCameras` destroys runtime and shows `カメラ選択`.
+- Unit: if old device id is absent after enumeration, selection defaults to available distinct devices and shows concise copy.
+- Unit: if fewer than two cameras remain, show existing two-camera-required error.
+- E2E: fake camera list changes, trigger reselect button, dropdown reflects refreshed devices, game can start again with two distinct cameras.
+- Keep real track unplug out of E2E; use mocks.
+
+**Dependencies on M3-M8 contracts**
+
+- M3/M4: device selection requires distinct devices.
+- M7 R2: runtime `retry()` remains for result retry; reselect path can destroy/recreate runtime.
+- M8: preserve same-lane calibration only in diagnostic workbench; game runtime remains default-only unless M8 introduces game calibration injection.
+
+### 9. Verify retry path cleanup with track-ended listeners
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `src/app/balloonGameRuntime.ts` only if tests expose listener leaks.
+- Modify tests: `tests/integration/balloonGameRuntime.test.ts`
+
+**Implementation notes**
+
+- `retry()` already does:
+  - engine reset;
+  - `stopCameraTracking()`;
+  - mapper resets;
+  - `inputFusionMapper.resetAll()`;
+  - fresh `startCameraTracking()`.
+- M9 must add assertions that retry also detaches track-ended observers and does not leave old stream listeners active.
+- If implementation uses lane-local observer cleanup, call it inside the same cleanup path as callback cancellation and tracker cleanup.
+- Avoid duplicate listener accumulation after repeated `retry()`.
+
+**Test plan**
+
+- Integration: start runtime, capture fake track listener count, call `retry()`, old fake track has zero ended listeners.
+- Integration: ended event on old track after retry does not mutate the new runtime lane health.
+- Integration: retry after one lane `captureLost` starts exactly two new streams and two new trackers.
+- Integration: repeated retry does not increase listener count on active tracks beyond one per track.
+
+**Dependencies on M3-M8 contracts**
+
+- M7 R2/R3: retry and lane release are known seams.
+- M6: reset all fusion buffers on retry.
+- Prior PR lesson: lifecycle race on stream/tracker must be verified directly.
+
+### 10. Add reconnect cooldown / error-budget policy without auto-restart loops
+
+**Scope:** `~≤2h`
+
+**Files to create / modify**
+
+- Create: `src/features/camera/reconnectPolicy.ts`
+- Modify: `src/features/diagnostic-workbench/DiagnosticWorkbench.ts`
+- Modify: `src/app/balloonGamePage.ts` if manual reselect start clicks need throttling.
+- Add tests:
+  - `tests/unit/features/camera/reconnectPolicy.test.ts`
+  - `tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts`
+  - `tests/unit/app/balloonGamePage.test.ts` if app path uses the policy.
+
+**Implementation notes**
+
+- M9 should not auto-reopen streams on `devicechange` or track end.
+- Add a small deterministic policy to prevent repeated manual start attempts from spinning trackers:
+  - named constants such as `CAMERA_RECONNECT_COOLDOWN_MS = 1_000` and `MAX_CAMERA_RECONNECT_ATTEMPTS = 3`;
+  - `createReconnectBudget(nowMs)` with methods like `canAttempt(role)` / `recordFailure(role)` / `recordSuccess(role)`.
+- Apply policy only where repeated user/device events can call stream open:
+  - workbench `assignDevices()` / `swapRoles()`;
+  - game page reselect start if M9 adds a direct reconnect button.
+- After success, clear failure budget for that lane or pair.
+- On cooldown block, do not start trackers; surface concise copy:
+  - workbench: inline error with cause/impact/reproduction/next action if fitting existing error model;
+  - game page: `"少し待ってからもう一度お試しください"`.
+
+**Test plan**
+
+- Unit: failures within cooldown block repeated open attempts.
+- Unit: success clears budget.
+- Unit: devicechange refresh never consumes reconnect budget.
+- Unit: blocked attempt does not call `createDevicePinnedStream`.
+- Unit: constants are named and tested with `toBe`.
+
+**Dependencies on M3-M8 contracts**
+
+- M3: no silent camera switching.
+- M7: game page stays production-clean.
+- Prior PR lessons: named threshold constants, deterministic rules over prompt-only behavior.
+
+### 11. Preserve or replay M8 calibration across same-lane reconnect
+
+**Scope:** `~≤2h`
+
+**Files to modify after M8 lands**
+
+- Likely modify: `src/features/diagnostic-workbench/liveLandmarkInspection.ts`
+- Likely modify: `src/features/diagnostic-workbench/renderWorkbench.ts`
+- Likely modify: `tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts`
+- Possibly modify: M8-created calibration renderer tests.
+
+**Implementation notes**
+
+- This step depends on the final M8 implementation.
+- If M8 creates session-scoped calibration state in `liveLandmarkInspection.ts`, M9 should preserve it across:
+  - track ended;
+  - same lane same role reselect;
+  - same lane same role device reconnect where the user chooses the same device label/id again.
+- Do reset calibration on:
+  - explicit calibration reset button;
+  - destroying the workbench;
+  - role swap if calibration semantics are role-bound and the lane role changes.
+- Do not persist calibration to storage.
+- Important contradiction:
+  - M8 decomposition currently says reselect resets lane calibration to defaults.
+  - M9 requirement says same-lane reconnect should not reset session calibration.
+  - Resolve this in spec/Issue discussion or in a small M8/M9 handoff note before code changes.
+- USB re-enumeration caveat:
+  - browser may return the same `deviceId` for a new physical connection, or a new `deviceId` for the same hardware;
+  - treat preservation as lane-role/session-scoped, not as proof of physical identity.
+
+**Test plan**
+
+- Unit: front calibration changed, front track ended, user reselects front lane, calibration value remains.
+- Unit: side calibration changed, side track ended, user reselects side lane, calibration value remains.
+- Unit: explicit reset still restores defaults.
+- Unit: role swap behavior matches final agreed policy.
+- E2E: if M8 exposes calibration sliders, change slider, reselect same lane, value remains visible.
+
+**Dependencies on M3-M8 contracts**
+
+- M8: exact calibration state names and methods.
+- M6: fusion frame remains calibration-free.
+- M7: game page still does not expose calibration UI.
+
+### 12. Add browser smoke coverage for live-trial hardening
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- Modify: `tests/e2e/diagnostic.smoke.spec.ts`
+- Modify: `tests/e2e/home.smoke.spec.ts`
+
+**Implementation notes**
+
+- Do not attempt real USB unplug in Playwright.
+- Extend fake media devices with:
+  - controllable `enumerateDevices()` result;
+  - fake `MediaStream` containing fake video tracks where possible;
+  - dispatchable `devicechange` event.
+- Diagnostic smoke:
+  - permission -> selection -> preview still works;
+  - dispatch `devicechange`;
+  - click `再選択`;
+  - dropdown shows refreshed device list.
+- Home smoke:
+  - game remains free of diagnostic selectors;
+  - capture-lost reselect action is concise and production-facing if the test can drive fake fused state or fake track end;
+  - no calibration selectors or debug constants appear.
+
+**Test plan**
+
+- E2E diagnostic: refreshed dropdown includes replugged camera label.
+- E2E home: no `#wb-fusion-panel`, `[data-side-trigger-tuning]`, `[data-fusion-tuning]`, calibration selectors, or raw health strings.
+- E2E home: reselect path returns to camera selection without page reload.
+
+**Dependencies on M3-M8 contracts**
+
+- M3: diagnostic entry remains separate.
+- M7: home game flow and result retry still work.
+- M8: calibration controls remain diagnostic-only.
+
+### 13. Quality gates and final verification
+
+**Scope:** `~≤2h`
+
+**Files to modify**
+
+- None unless failures identify scoped fixes.
+
+**Commands**
+
+- After camera helper work:
+  - `npm run test -- tests/unit/features/camera`
+- After diagnostic lifecycle work:
+  - `npm run test -- tests/unit/features/diagnostic-workbench`
+- After game runtime/page work:
+  - `npm run test -- tests/integration/balloonGameRuntime.test.ts tests/unit/app`
+- After fusion captureLost lock-in:
+  - `npm run test -- tests/unit/features/input-fusion tests/replay`
+- Before marking M9 complete:
+  - `npm run check`
+- Because M9 touches browser entry behavior:
+  - `npm run test:e2e`
+
+**Expected outcome**
+
+- `npm run check` passes lint, typecheck, unit/integration/replay, and knip.
+- `npm run test:e2e` passes diagnostic and home smoke.
+- If Playwright/browser installation blocks e2e, record exact failure and the passing lower-level gates.
+
+**Dependencies on M3-M8 contracts**
+
+- All lane contracts remain explicit.
+- Knip must see new helpers through real imports.
+- No dead exported constants.
+
+## 3. Risk register
+
+- **Stream/tracker left dangling after `track.onended`:** Use the same cleanup discipline as M6 R1 / M7 R3. Track end must cancel frame callbacks, cleanup tracker, stop/remove stream references, and detach listeners once.
+- **Duplicate `onended` listeners after retry:** Use `addEventListener` plus cleanup object. Tests must assert old fake tracks have zero listeners after `retry()` / `destroy()`.
+- **Device dropdown refresh race with active stream:** `devicechange` should refresh `devices` only. It must not stop active streams or auto-open replacements while previewing/running.
+- **Calibration wiped on reconnect:** M8 decomposition and M9 requirement conflict. Resolve policy first; recommended M9 behavior is same-lane session calibration preservation.
+- **`captureLost` health never cleared after successful re-select:** Successful new lane start must set health `capturing -> tracking`, clear lane-lost snapshots, and clear fusion lane buffer through fresh frames.
+- **`devicechange` during `retry()` mid-flight:** Generation guards must prevent double-start and stale enumeration/open results from winning.
+- **Fusion pairing during reconnect window:** On loss entry, call `updateAimUnavailable()` / `updateTriggerUnavailable()` immediately so stale paired frames cannot survive the reconnect window.
+- **Browser returns same `deviceId` for different hardware after USB re-enum:** Do not treat `deviceId` as physical identity proof. Keep copy and calibration semantics lane/session-scoped.
+- **Stale video element after re-render:** Existing live inspection key includes stream ids and video elements. M9 must keep that check and restart tracking when DOM video elements are replaced.
+- **Process-frame try/catch recovery regression:** Track end should be separate from detect/frame errors. Do not turn every transient bitmap failure into `captureLost`.
+- **Cooldown accidentally blocks legitimate manual reselect:** Cooldown should block repeated failing opens, not passive dropdown refresh or explicit reset after success.
+- **Game page becomes diagnostic:** Do not display raw `LaneHealthStatus`, timestamps, device IDs, threshold constants, or workbench panels.
+- **Shot fires from stale side trigger after side loss:** `updateTriggerUnavailable()` must reset shot consumption.
+- **M8 merge conflict in `liveLandmarkInspection.ts`:** M8 calibration snapshot handling and M9 capture-loss handling both touch per-frame state and reset paths. Keep changes small and tests focused.
+
+## 4. Quality gate sequence
+
+1. During each Red/Green loop, run the focused Vitest file for the touched module.
+2. After camera helpers and policies:
+   - `npm run test -- tests/unit/features/camera`
+3. After workbench lifecycle/devicechange:
+   - `npm run test -- tests/unit/features/diagnostic-workbench`
+4. After runtime/page reselect and HUD:
+   - `npm run test -- tests/unit/app tests/integration/balloonGameRuntime.test.ts`
+5. After fusion lock-in:
+   - `npm run test -- tests/unit/features/input-fusion tests/replay`
+6. Before completion:
+   - `npm run check`
+7. Because `diagnostic.html` and `index.html` behavior change:
+   - `npm run test:e2e`
+
+## 5. Boundaries reminder
+
+- No stereo expansion.
+- No IMU, depth, or other additional sensors.
+- No one-camera pseudo-side mode.
+- Preserve lane invariant:
+  - front = aim
+  - side = trigger
+  - fusion = pairing / shot-edge consumption
+- Game page remains production-clean:
+  - concise user-facing degraded-state messages only;
+  - no debug overlay;
+  - no workbench panels;
+  - no raw `captureLost` / `laneFailed` strings.
+- Diagnostic workbench behavior is additive:
+  - device-event visibility and capture-loss state are added;
+  - existing tuning/calibration controls are not renamed or removed.
+- No silent camera switching. Reconnect requires explicit user selection or retry.
+- No persistent calibration in M9.
+
+## 6. M8 coordination notes
+
+M9 likely overlaps with M8 in these files:
+
+- `src/features/diagnostic-workbench/liveLandmarkInspection.ts`
+  - Highest merge risk. M8 adds calibration state and per-frame calibration snapshots; M9 adds track-ended loss entry, cleanup, and unavailable fusion updates.
+- `src/features/diagnostic-workbench/renderWorkbench.ts`
+  - M8 adds calibration controls/state; M9 adds capture-lost health copy and device-event visibility.
+- `src/diagnostic-main.ts`
+  - M8 adds calibration event handlers; M9 adds `devicechange` observer and possibly reselect/device refresh wiring.
+- `src/app/balloonGameRuntime.ts`
+  - M8 may pass default calibration into mappers; M9 adds track-ended observers, capture-lost HUD logic, and cleanup tests.
+- `src/app/balloonGamePage.ts`
+  - M9 adds production-clean reselect path; M8 should not add game calibration UI.
+- `tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts`
+  - Both M8 and M9 add async lifecycle tests. Expect merge conflicts.
+- `tests/e2e/diagnostic.smoke.spec.ts`
+  - M8 calibration controls and M9 devicechange/reselect refresh both extend the same smoke path.
+- `tests/e2e/home.smoke.spec.ts`
+  - M8 asserts calibration UI absence; M9 asserts capture-loss reselect UX and debug absence.
+- `tests/integration/balloonGameRuntime.test.ts`
+  - M8 default calibration wiring and M9 capture-loss/retry cleanup both touch runtime setup fakes.
+
+Merge-risk flags:
+
+- Decide calibration reset-vs-preserve before implementation.
+- If M8 changes mapper update signatures, M9 runtime/workbench tasks must use the M8 signatures instead of post-M7 signatures.
+- If M8 adds calibration state to `WorkbenchInspectionState`, M9 reset paths must preserve that state intentionally.
+- If M8 creates new calibration renderers, M9 should not fold capture-loss UI into those files.
+
+## 7. Out-of-scope for M9
+
+- Stereo reconstruction or stereo calibration.
+- Sensor fusion beyond the two existing camera lanes.
+- Persistent calibration storage in `localStorage`, `IndexedDB`, cookies, server, config files, or URL params.
+- Multi-user sessions.
+- Camera permission denial flow beyond the existing single prompt retry path.
+- Automatic camera failover to another detected device.
+- One-camera fallback or pseudo-side mode.
+- New gameplay mechanics, scoring changes, or Phaser migration.
+- Debug/diagnostic overlays on the game page.

--- a/src/app/balloonGamePage.ts
+++ b/src/app/balloonGamePage.ts
@@ -148,6 +148,19 @@ const errorStateForPermission = (result: PermissionResult): GamePageState => {
   };
 };
 
+const hasDeviceId = (
+  devices: readonly MediaDeviceInfo[],
+  deviceId: string | undefined
+): deviceId is string =>
+  deviceId !== undefined &&
+  devices.some((device) => device.deviceId === deviceId);
+
+const firstDeviceIdExcept = (
+  devices: readonly MediaDeviceInfo[],
+  excludedDeviceId: string | undefined
+): string | undefined =>
+  devices.find((device) => device.deviceId !== excludedDeviceId)?.deviceId;
+
 export const createBalloonGamePage = ({
   requestCameraPermission: requestPermission = requestCameraPermission,
   enumerateVideoDevices: enumerateDevices = enumerateVideoDevices,
@@ -165,10 +178,7 @@ export const createBalloonGamePage = ({
     }
   };
 
-  const startRuntime = (
-    frontDeviceId: string,
-    sideDeviceId: string
-  ): void => {
+  const startRuntime = (frontDeviceId: string, sideDeviceId: string): void => {
     if (root === undefined) {
       return;
     }
@@ -218,6 +228,59 @@ export const createBalloonGamePage = ({
     runtime.start();
   };
 
+  const reselectCameras = async (): Promise<void> => {
+    runtime?.destroy();
+    runtime = undefined;
+
+    try {
+      const devices = await enumerateDevices();
+
+      if (devices.length < 2) {
+        commit({
+          ...initialState(),
+          screen: "error",
+          errorTitle: "カメラが1台しか検出されません",
+          errorCause: "このゲームには2台のカメラが必要です。",
+          errorNextAction: "別のカメラを接続してからリトライしてください。"
+        });
+        return;
+      }
+
+      const previousFrontId = state.selectedFrontDeviceId;
+      const previousSideId = state.selectedSideDeviceId;
+      const selectedFrontDeviceId = hasDeviceId(devices, previousFrontId)
+        ? previousFrontId
+        : devices[0]?.deviceId;
+      const selectedSideDeviceId =
+        hasDeviceId(devices, previousSideId) &&
+        previousSideId !== selectedFrontDeviceId
+          ? previousSideId
+          : firstDeviceIdExcept(devices, selectedFrontDeviceId);
+      const selectionChanged =
+        selectedFrontDeviceId !== previousFrontId ||
+        selectedSideDeviceId !== previousSideId;
+
+      commit({
+        ...state,
+        screen: "deviceSelection",
+        devices,
+        selectedFrontDeviceId,
+        selectedSideDeviceId,
+        selectionError: selectionChanged
+          ? "切断されたカメラを選び直してください。"
+          : undefined
+      });
+    } catch (error: unknown) {
+      commit({
+        ...initialState(),
+        screen: "error",
+        errorTitle: "カメラ一覧を取得できません",
+        errorCause: error instanceof Error ? error.message : String(error),
+        errorNextAction: "カメラ接続を確認してからリトライしてください。"
+      });
+    }
+  };
+
   const handleClick = (event: Event): void => {
     const target = event.target as Element | null;
     const action = target?.getAttribute("data-game-action");
@@ -232,11 +295,18 @@ export const createBalloonGamePage = ({
       return;
     }
 
+    if (action === "reselectCameras") {
+      void reselectCameras();
+      return;
+    }
+
     if (action === "startSelectedCameras" && root !== undefined) {
-      const frontId =
-        root.querySelector<HTMLSelectElement>("#front-camera-select")?.value;
-      const sideId =
-        root.querySelector<HTMLSelectElement>("#side-camera-select")?.value;
+      const frontId = root.querySelector<HTMLSelectElement>(
+        "#front-camera-select"
+      )?.value;
+      const sideId = root.querySelector<HTMLSelectElement>(
+        "#side-camera-select"
+      )?.value;
 
       if (frontId !== undefined && sideId !== undefined) {
         page.selectCameras(frontId, sideId);

--- a/src/app/balloonGamePage.ts
+++ b/src/app/balloonGamePage.ts
@@ -376,13 +376,13 @@ export const createBalloonGamePage = ({
         const devices = await enumerateDevices();
 
         if (devices.length < 2) {
-          commit({
-            ...initialState(),
-            screen: "error",
-            errorTitle: "カメラが1台しか検出されません",
-            errorCause: "このゲームには2台のカメラが必要です。",
-            errorNextAction: "別のカメラを接続してからリトライしてください。"
-          });
+          commit(
+            buildCameraErrorState(
+              "カメラが1台しか検出されません",
+              "このゲームには2台のカメラが必要です。",
+              "別のカメラを接続してからリトライしてください。"
+            )
+          );
           return;
         }
 
@@ -395,13 +395,13 @@ export const createBalloonGamePage = ({
           selectionError: undefined
         });
       } catch (error: unknown) {
-        commit({
-          ...initialState(),
-          screen: "error",
-          errorTitle: "カメラ一覧を取得できません",
-          errorCause: error instanceof Error ? error.message : String(error),
-          errorNextAction: "カメラ接続を確認してからリトライしてください。"
-        });
+        commit(
+          buildCameraErrorState(
+            "カメラ一覧を取得できません",
+            error instanceof Error ? error.message : String(error),
+            "カメラ接続を確認してからリトライしてください。"
+          )
+        );
       }
     },
     selectCameras(frontDeviceId, sideDeviceId) {

--- a/src/app/balloonGamePage.ts
+++ b/src/app/balloonGamePage.ts
@@ -155,11 +155,38 @@ const hasDeviceId = (
   deviceId !== undefined &&
   devices.some((device) => device.deviceId === deviceId);
 
-const firstDeviceIdExcept = (
+const firstDeviceIdExcluding = (
   devices: readonly MediaDeviceInfo[],
-  excludedDeviceId: string | undefined
+  excludedDeviceIds: readonly (string | undefined)[]
 ): string | undefined =>
-  devices.find((device) => device.deviceId !== excludedDeviceId)?.deviceId;
+  devices.find((device) => !excludedDeviceIds.includes(device.deviceId))
+    ?.deviceId;
+
+const selectReselectedCameraIds = (
+  devices: readonly MediaDeviceInfo[],
+  previousFrontId: string | undefined,
+  previousSideId: string | undefined
+): {
+  readonly selectedFrontDeviceId: string | undefined;
+  readonly selectedSideDeviceId: string | undefined;
+} => {
+  const previousFrontPresent = hasDeviceId(devices, previousFrontId);
+  const previousSidePresent = hasDeviceId(devices, previousSideId);
+  const selectedFrontDeviceId = previousFrontPresent
+    ? previousFrontId
+    : (firstDeviceIdExcluding(devices, [
+        previousSidePresent ? previousSideId : undefined
+      ]) ?? devices[0]?.deviceId);
+  const selectedSideDeviceId =
+    previousSidePresent && previousSideId !== selectedFrontDeviceId
+      ? previousSideId
+      : firstDeviceIdExcluding(devices, [
+          selectedFrontDeviceId,
+          previousFrontPresent ? previousFrontId : undefined
+        ]);
+
+  return { selectedFrontDeviceId, selectedSideDeviceId };
+};
 
 export const createBalloonGamePage = ({
   requestCameraPermission: requestPermission = requestCameraPermission,
@@ -169,6 +196,19 @@ export const createBalloonGamePage = ({
   let root: HTMLElement | undefined;
   let state = initialState();
   let runtime: BalloonGameRuntime | undefined;
+  let reselectGeneration = 0;
+
+  const buildCameraErrorState = (
+    title: string,
+    cause: string,
+    nextAction: string
+  ): GamePageState => ({
+    ...initialState(),
+    screen: "error",
+    errorTitle: title,
+    errorCause: cause,
+    errorNextAction: nextAction
+  });
 
   const commit = (nextState: GamePageState): void => {
     state = nextState;
@@ -229,33 +269,33 @@ export const createBalloonGamePage = ({
   };
 
   const reselectCameras = async (): Promise<void> => {
+    reselectGeneration += 1;
+    const generation = reselectGeneration;
     runtime?.destroy();
     runtime = undefined;
 
     try {
       const devices = await enumerateDevices();
 
+      if (generation !== reselectGeneration) {
+        return;
+      }
+
       if (devices.length < 2) {
-        commit({
-          ...initialState(),
-          screen: "error",
-          errorTitle: "カメラが1台しか検出されません",
-          errorCause: "このゲームには2台のカメラが必要です。",
-          errorNextAction: "別のカメラを接続してからリトライしてください。"
-        });
+        commit(
+          buildCameraErrorState(
+            "カメラが1台しか検出されません",
+            "このゲームには2台のカメラが必要です。",
+            "別のカメラを接続してからリトライしてください。"
+          )
+        );
         return;
       }
 
       const previousFrontId = state.selectedFrontDeviceId;
       const previousSideId = state.selectedSideDeviceId;
-      const selectedFrontDeviceId = hasDeviceId(devices, previousFrontId)
-        ? previousFrontId
-        : devices[0]?.deviceId;
-      const selectedSideDeviceId =
-        hasDeviceId(devices, previousSideId) &&
-        previousSideId !== selectedFrontDeviceId
-          ? previousSideId
-          : firstDeviceIdExcept(devices, selectedFrontDeviceId);
+      const { selectedFrontDeviceId, selectedSideDeviceId } =
+        selectReselectedCameraIds(devices, previousFrontId, previousSideId);
       const selectionChanged =
         selectedFrontDeviceId !== previousFrontId ||
         selectedSideDeviceId !== previousSideId;
@@ -271,13 +311,17 @@ export const createBalloonGamePage = ({
           : undefined
       });
     } catch (error: unknown) {
-      commit({
-        ...initialState(),
-        screen: "error",
-        errorTitle: "カメラ一覧を取得できません",
-        errorCause: error instanceof Error ? error.message : String(error),
-        errorNextAction: "カメラ接続を確認してからリトライしてください。"
-      });
+      if (generation !== reselectGeneration) {
+        return;
+      }
+
+      commit(
+        buildCameraErrorState(
+          "カメラ一覧を取得できません",
+          error instanceof Error ? error.message : String(error),
+          "カメラ接続を確認してからリトライしてください。"
+        )
+      );
     }
   };
 
@@ -375,6 +419,7 @@ export const createBalloonGamePage = ({
       startRuntime(frontDeviceId, sideDeviceId);
     },
     destroy() {
+      reselectGeneration += 1;
       runtime?.destroy();
       root?.removeEventListener("click", handleClick);
       root = undefined;

--- a/src/app/balloonGameRuntime.ts
+++ b/src/app/balloonGameRuntime.ts
@@ -227,6 +227,18 @@ export const createBalloonGameRuntime = ({
   const trackers: MediaPipeHandTracker[] = [];
   const laneStops: (() => void)[] = [];
 
+  const safeCleanupTracker = (tracker: MediaPipeHandTracker): void => {
+    removeItem(trackers, tracker);
+
+    try {
+      void Promise.resolve(tracker.cleanup()).catch((error: unknown) => {
+        console.error("[balloon game runtime] tracker cleanup failed", error);
+      });
+    } catch (error: unknown) {
+      console.error("[balloon game runtime] tracker cleanup failed", error);
+    }
+  };
+
   if (initialBalloons !== undefined) {
     engine.forceBalloons([...initialBalloons]);
   }
@@ -521,8 +533,7 @@ export const createBalloonGameRuntime = ({
       stream.stop();
 
       if (tracker !== undefined) {
-        removeItem(trackers, tracker);
-        void tracker.cleanup();
+        safeCleanupTracker(tracker);
       }
     };
 
@@ -553,7 +564,7 @@ export const createBalloonGameRuntime = ({
     }
 
     if (!laneStillActive()) {
-      void tracker.cleanup();
+      safeCleanupTracker(tracker);
       return;
     }
 
@@ -677,8 +688,8 @@ export const createBalloonGameRuntime = ({
     }
     streams.length = 0;
 
-    for (const tracker of trackers) {
-      void tracker.cleanup();
+    for (const tracker of [...trackers]) {
+      safeCleanupTracker(tracker);
     }
     trackers.length = 0;
 

--- a/src/app/balloonGameRuntime.ts
+++ b/src/app/balloonGameRuntime.ts
@@ -7,6 +7,7 @@ import {
   type DevicePinnedStream
 } from "../features/camera/createDevicePinnedStream";
 import { createFrameTimestamp } from "../features/camera/frameTimestamp";
+import { observeTrackEnded } from "../features/camera/observeTrackEnded";
 import {
   createFrontAimMapper,
   defaultFrontAimCalibration,
@@ -160,6 +161,14 @@ const statusMessageForFusedFrame = (
     return "入力を準備中";
   }
 
+  if (
+    frame.fusionRejectReason === "laneFailed" &&
+    (frame.frontSource.laneHealth === "captureLost" ||
+      frame.sideSource.laneHealth === "captureLost")
+  ) {
+    return "カメラが切断されました";
+  }
+
   if (frame.fusionRejectReason !== "none") {
     return degradedInputMessages[frame.fusionRejectReason];
   }
@@ -232,6 +241,10 @@ export const createBalloonGameRuntime = ({
 
   const renderHud = (): void => {
     const currentFusedFrame = readFusedInputFrame?.() ?? latestFusedFrame;
+    const statusMessage =
+      session.state === "playing"
+        ? statusMessageForFusedFrame(currentFusedFrame)
+        : undefined;
 
     const hudHtml = renderGameHud({
       score: engine.score,
@@ -239,9 +252,10 @@ export const createBalloonGameRuntime = ({
       multiplier: engine.multiplier,
       timeRemainingMs: session.timeRemainingMs,
       countdownLabel: session.countdownLabel,
-      statusMessage:
-        session.state === "playing"
-          ? statusMessageForFusedFrame(currentFusedFrame)
+      statusMessage,
+      statusAction:
+        statusMessage === "カメラが切断されました"
+          ? { action: "reselectCameras", label: "カメラを選び直す" }
           : undefined,
       result:
         session.state === "result"
@@ -433,6 +447,9 @@ export const createBalloonGameRuntime = ({
     let timeoutId: number | undefined;
     let laneStopped = false;
     let consecutiveFrameErrors = 0;
+    const trackEndedObserver: { current?: { stop(): void } } = {};
+    let laneResourcesReleased = false;
+    let tracker: MediaPipeHandTracker | undefined;
     const laneStillActive = (): boolean => !stopped && !laneStopped;
 
     const setLaneHealth = (health: LaneHealthStatus): void => {
@@ -445,6 +462,7 @@ export const createBalloonGameRuntime = ({
 
     const stopLane = (): void => {
       laneStopped = true;
+      trackEndedObserver.current?.stop();
 
       if (
         callbackId !== undefined &&
@@ -471,7 +489,52 @@ export const createBalloonGameRuntime = ({
     streams.push(stream);
     video.srcObject = stream.stream;
 
-    let tracker: MediaPipeHandTracker;
+    const timestampNow = (): FrameTimestamp => {
+      const now = performance.now();
+
+      return createFrameTimestamp({ expectedDisplayTime: now }, now);
+    };
+
+    const updateUnavailable = (timestamp: FrameTimestamp): void => {
+      if (role === "frontAim") {
+        latestFusedFrame = inputFusionMapper.updateAimUnavailable(
+          timestamp,
+          currentFusionContext()
+        ).fusedFrame;
+      } else {
+        latestFusedFrame = inputFusionMapper.updateTriggerUnavailable(
+          timestamp,
+          currentFusionContext()
+        ).fusedFrame;
+      }
+    };
+
+    const releaseLaneResources = (): void => {
+      if (laneResourcesReleased) {
+        return;
+      }
+
+      laneResourcesReleased = true;
+      stopLane();
+      removeItem(laneStops, stopLane);
+      removeItem(streams, stream);
+      stream.stop();
+
+      if (tracker !== undefined) {
+        removeItem(trackers, tracker);
+        void tracker.cleanup();
+      }
+    };
+
+    trackEndedObserver.current = observeTrackEnded(stream.stream, () => {
+      if (!laneStillActive()) {
+        return;
+      }
+
+      setLaneHealth("captureLost");
+      updateUnavailable(timestampNow());
+      releaseLaneResources();
+    });
 
     try {
       tracker = await createTracker({
@@ -485,27 +548,17 @@ export const createBalloonGameRuntime = ({
         console.error("[balloon game runtime] tracker startup failed", error);
         setLaneHealth("failed");
       }
-      stream.stop();
+      releaseLaneResources();
       return;
     }
 
     if (!laneStillActive()) {
-      stream.stop();
       void tracker.cleanup();
       return;
     }
 
     trackers.push(tracker);
     setLaneHealth("tracking");
-
-    const releaseLaneResources = (): void => {
-      stopLane();
-      removeItem(laneStops, stopLane);
-      removeItem(streams, stream);
-      removeItem(trackers, tracker);
-      stream.stop();
-      void tracker.cleanup();
-    };
 
     const scheduleVideoFrame = (): void => {
       if (!laneStillActive()) {
@@ -524,26 +577,17 @@ export const createBalloonGameRuntime = ({
       }, VIDEO_FRAME_FALLBACK_INTERVAL_MS);
     };
 
-    const updateUnavailable = (timestamp: FrameTimestamp): void => {
-      if (role === "frontAim") {
-        latestFusedFrame = inputFusionMapper.updateAimUnavailable(
-          timestamp,
-          currentFusionContext()
-        ).fusedFrame;
-      } else {
-        latestFusedFrame = inputFusionMapper.updateTriggerUnavailable(
-          timestamp,
-          currentFusionContext()
-        ).fusedFrame;
-      }
-    };
-
     async function processVideoFrame(metadata: FrameTimingLike): Promise<void> {
       if (!laneStillActive()) {
         return;
       }
 
       const timestamp = createFrameTimestamp(metadata, performance.now());
+      const activeTracker = tracker;
+
+      if (activeTracker === undefined) {
+        return;
+      }
 
       if (!videoReadyForBitmap(video)) {
         updateUnavailable(timestamp);
@@ -560,7 +604,7 @@ export const createBalloonGameRuntime = ({
           return;
         }
 
-        const detection = await tracker.detect(
+        const detection = await activeTracker.detect(
           bitmap,
           timestamp.frameTimestampMs
         );

--- a/src/app/gameHud.ts
+++ b/src/app/gameHud.ts
@@ -6,6 +6,11 @@ interface GameHudResult {
   readonly bestCombo: number;
 }
 
+interface GameHudStatusAction {
+  readonly action: "reselectCameras";
+  readonly label: string;
+}
+
 interface GameHudViewModel {
   readonly score: number;
   readonly combo: number;
@@ -13,6 +18,7 @@ interface GameHudViewModel {
   readonly timeRemainingMs: number;
   readonly countdownLabel: CountdownLabel | undefined;
   readonly statusMessage: string | undefined;
+  readonly statusAction?: GameHudStatusAction | undefined;
   readonly result: GameHudResult | undefined;
 }
 
@@ -33,12 +39,17 @@ export const renderGameHud = ({
   timeRemainingMs,
   countdownLabel,
   statusMessage,
+  statusAction,
   result
 }: GameHudViewModel): string => {
+  const statusActionHtml =
+    statusAction === undefined
+      ? ""
+      : `<button class="screen-button hud-status-action" data-game-action="${escapeHTML(statusAction.action)}">${escapeHTML(statusAction.label)}</button>`;
   const status =
     statusMessage === undefined
       ? ""
-      : `<p class="hud-status">${escapeHTML(statusMessage)}</p>`;
+      : `<div class="hud-status-row"><p class="hud-status">${escapeHTML(statusMessage)}</p>${statusActionHtml}</div>`;
   const countdown =
     countdownLabel === undefined
       ? ""

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -1,4 +1,5 @@
 import "./styles/diagnostic.css";
+import { observeDeviceChange } from "./features/camera/observeDeviceChange";
 import {
   createDiagnosticWorkbench,
   type DiagnosticWorkbench
@@ -14,6 +15,16 @@ if (!root) {
 
 const workbench: DiagnosticWorkbench = createDiagnosticWorkbench();
 const liveInspection = createLiveLandmarkInspection();
+
+const runAction = (actionPromise: Promise<void>): void => {
+  void actionPromise.catch((error: unknown) => {
+    console.error("Diagnostic workbench action failed", error);
+  });
+};
+
+const deviceChangeObserver = observeDeviceChange(() => {
+  runAction(workbench.refreshDevicesFromDeviceChange());
+});
 
 const render = (): void => {
   const state = workbench.getState();
@@ -71,11 +82,6 @@ const handleClick = (e: MouseEvent): void => {
   }
 
   const action = actionEl.dataset["wbAction"];
-  const runAction = (actionPromise: Promise<void>): void => {
-    void actionPromise.catch((error: unknown) => {
-      console.error("Diagnostic workbench action failed", error);
-    });
-  };
 
   switch (action) {
     case "requestPermission":
@@ -188,6 +194,7 @@ root.addEventListener("input", (e: Event) => {
 });
 workbench.subscribe(render);
 window.addEventListener("beforeunload", () => {
+  deviceChangeObserver.stop();
   liveInspection.destroy();
   workbench.destroy();
 });

--- a/src/features/camera/observeDeviceChange.ts
+++ b/src/features/camera/observeDeviceChange.ts
@@ -1,0 +1,72 @@
+interface DeviceChangeObserver {
+  stop(): void;
+}
+
+interface MediaDevicesWithEvents extends Partial<MediaDevices> {
+  ondevicechange?: ((event: Event) => void) | null;
+}
+
+const currentMediaDevices = (): MediaDevicesWithEvents | undefined =>
+  (
+    globalThis as {
+      readonly navigator?: { readonly mediaDevices?: MediaDevicesWithEvents };
+    }
+  ).navigator?.mediaDevices;
+
+export const observeDeviceChange = (
+  callback: () => void
+): DeviceChangeObserver => {
+  const mediaDevices = currentMediaDevices();
+
+  if (mediaDevices === undefined) {
+    return {
+      stop() {
+        return undefined;
+      }
+    };
+  }
+
+  let stopped = false;
+
+  if (typeof mediaDevices.addEventListener === "function") {
+    const handler = (): void => {
+      if (!stopped) {
+        callback();
+      }
+    };
+
+    mediaDevices.addEventListener("devicechange", handler);
+
+    return {
+      stop() {
+        if (stopped) {
+          return;
+        }
+
+        stopped = true;
+        mediaDevices.removeEventListener?.("devicechange", handler);
+      }
+    };
+  }
+
+  const previous = mediaDevices.ondevicechange ?? null;
+
+  mediaDevices.ondevicechange = (event: Event): void => {
+    previous?.(event);
+
+    if (!stopped) {
+      callback();
+    }
+  };
+
+  return {
+    stop() {
+      if (stopped) {
+        return;
+      }
+
+      stopped = true;
+      mediaDevices.ondevicechange = previous;
+    }
+  };
+};

--- a/src/features/camera/observeDeviceChange.ts
+++ b/src/features/camera/observeDeviceChange.ts
@@ -51,13 +51,15 @@ export const observeDeviceChange = (
 
   const previous = mediaDevices.ondevicechange ?? null;
 
-  mediaDevices.ondevicechange = (event: Event): void => {
+  const handler = (event: Event): void => {
     previous?.(event);
 
     if (!stopped) {
       callback();
     }
   };
+
+  mediaDevices.ondevicechange = handler;
 
   return {
     stop() {
@@ -66,7 +68,10 @@ export const observeDeviceChange = (
       }
 
       stopped = true;
-      mediaDevices.ondevicechange = previous;
+
+      if (mediaDevices.ondevicechange === handler) {
+        mediaDevices.ondevicechange = previous;
+      }
     }
   };
 };

--- a/src/features/camera/observeDeviceChange.ts
+++ b/src/features/camera/observeDeviceChange.ts
@@ -21,7 +21,7 @@ export const observeDeviceChange = (
   if (mediaDevices === undefined) {
     return {
       stop() {
-        return undefined;
+        return;
       }
     };
   }

--- a/src/features/camera/observeTrackEnded.ts
+++ b/src/features/camera/observeTrackEnded.ts
@@ -28,7 +28,7 @@ const videoTracksFor = (stream: MediaStream): TrackLike[] => {
     );
   }
 
-  return [];
+  throw new Error("MediaStream does not support getVideoTracks or getTracks");
 };
 
 export const observeTrackEnded = (

--- a/src/features/camera/observeTrackEnded.ts
+++ b/src/features/camera/observeTrackEnded.ts
@@ -38,10 +38,6 @@ export const observeTrackEnded = (
   const cleanup: (() => void)[] = [];
 
   for (const track of videoTracksFor(stream)) {
-    if (track.kind !== "video") {
-      continue;
-    }
-
     const handler = (): void => {
       callback({
         trackId: track.id,

--- a/src/features/camera/observeTrackEnded.ts
+++ b/src/features/camera/observeTrackEnded.ts
@@ -1,0 +1,74 @@
+export interface TrackEndedPayload {
+  readonly trackId: string;
+  readonly readyState: MediaStreamTrackState;
+  readonly label?: string | undefined;
+}
+
+interface TrackEndedObserver {
+  stop(): void;
+}
+
+type TrackLike = Pick<
+  MediaStreamTrack,
+  "addEventListener" | "removeEventListener" | "id" | "kind" | "readyState"
+> & {
+  readonly label?: string;
+};
+
+const videoTracksFor = (stream: MediaStream): TrackLike[] => {
+  const candidate = stream as Partial<MediaStream>;
+
+  if (typeof candidate.getVideoTracks === "function") {
+    return candidate.getVideoTracks() as TrackLike[];
+  }
+
+  if (typeof candidate.getTracks === "function") {
+    return (candidate.getTracks() as TrackLike[]).filter(
+      (track) => track.kind === "video"
+    );
+  }
+
+  return [];
+};
+
+export const observeTrackEnded = (
+  stream: MediaStream,
+  callback: (payload: TrackEndedPayload) => void
+): TrackEndedObserver => {
+  const cleanup: (() => void)[] = [];
+
+  for (const track of videoTracksFor(stream)) {
+    if (track.kind !== "video") {
+      continue;
+    }
+
+    const handler = (): void => {
+      callback({
+        trackId: track.id,
+        readyState: track.readyState,
+        label: track.label
+      });
+    };
+
+    track.addEventListener("ended", handler);
+    cleanup.push(() => {
+      track.removeEventListener("ended", handler);
+    });
+  }
+
+  let stopped = false;
+
+  return {
+    stop() {
+      if (stopped) {
+        return;
+      }
+
+      stopped = true;
+
+      for (const fn of cleanup) {
+        fn();
+      }
+    }
+  };
+};

--- a/src/features/camera/reconnectPolicy.ts
+++ b/src/features/camera/reconnectPolicy.ts
@@ -1,0 +1,44 @@
+export const CAMERA_RECONNECT_COOLDOWN_MS = 1_000;
+export const MAX_CAMERA_RECONNECT_ATTEMPTS = 3;
+
+interface FailureEntry {
+  readonly count: number;
+  readonly lastFailureMs: number;
+}
+
+interface ReconnectBudget {
+  canAttempt(key: string, nowMs: number): boolean;
+  recordFailure(key: string, nowMs: number): void;
+  recordSuccess(key: string): void;
+}
+
+export const createReconnectBudget = (): ReconnectBudget => {
+  const failures = new Map<string, FailureEntry>();
+
+  const entryFresh = (entry: FailureEntry, nowMs: number): boolean =>
+    nowMs - entry.lastFailureMs <= CAMERA_RECONNECT_COOLDOWN_MS;
+
+  return {
+    canAttempt(key, nowMs) {
+      const entry = failures.get(key);
+
+      if (entry === undefined || !entryFresh(entry, nowMs)) {
+        return true;
+      }
+
+      return entry.count < MAX_CAMERA_RECONNECT_ATTEMPTS;
+    },
+    recordFailure(key, nowMs) {
+      const previous = failures.get(key);
+      const count =
+        previous !== undefined && entryFresh(previous, nowMs)
+          ? previous.count + 1
+          : 1;
+
+      failures.set(key, { count, lastFailureMs: nowMs });
+    },
+    recordSuccess(key) {
+      failures.delete(key);
+    }
+  };
+};

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -93,6 +93,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   let openGeneration = 0;
   let requestGeneration = 0;
   let deviceRefreshGeneration = 0;
+  let permissionGranted = false;
 
   const emit = (): void => {
     for (const fn of listeners) {
@@ -283,7 +284,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     sideId: string,
     preservePreviewOnFailure: boolean
   ): Promise<void> => {
-    const reconnectKey = `${frontId}:${sideId}`;
+    const reconnectKey = JSON.stringify([frontId, sideId]);
     const nowMs = Date.now();
 
     if (!reconnectBudget.canAttempt(reconnectKey, nowMs)) {
@@ -431,6 +432,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     async requestPermission() {
       requestGeneration += 1;
       openGeneration += 1;
+      permissionGranted = false;
       const myGeneration = requestGeneration;
 
       stopCurrentStreams();
@@ -456,6 +458,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         update({ screen: errorScreenFor(error), error });
         return;
       }
+
+      permissionGranted = true;
 
       let devices: MediaDeviceInfo[];
 
@@ -503,7 +507,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     async refreshDevicesFromDeviceChange() {
-      if (state.screen === "permission") {
+      if (!permissionGranted) {
         return;
       }
 
@@ -562,6 +566,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       requestGeneration += 1;
       openGeneration += 1;
       deviceRefreshGeneration += 1;
+      permissionGranted = false;
       stopCurrentStreams();
       listeners.clear();
     }

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -95,6 +95,10 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   let deviceRefreshGeneration = 0;
   let permissionGranted = false;
 
+  const invalidateDeviceRefresh = (): void => {
+    deviceRefreshGeneration += 1;
+  };
+
   const emit = (): void => {
     for (const fn of listeners) {
       fn(state);
@@ -432,6 +436,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     async requestPermission() {
       requestGeneration += 1;
       openGeneration += 1;
+      invalidateDeviceRefresh();
       permissionGranted = false;
       const myGeneration = requestGeneration;
 
@@ -494,6 +499,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     async assignDevices(frontDeviceId: string, sideDeviceId: string) {
+      invalidateDeviceRefresh();
+
       if (frontDeviceId === sideDeviceId) {
         update({ error: createError("distinctDevicesRequired") });
         return;
@@ -511,7 +518,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
-      deviceRefreshGeneration += 1;
+      invalidateDeviceRefresh();
       const myGeneration = deviceRefreshGeneration;
 
       let devices: MediaDeviceInfo[];
@@ -535,6 +542,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     },
 
     async swapRoles() {
+      invalidateDeviceRefresh();
+
       const { frontAssignment, sideAssignment } = state;
 
       if (frontAssignment === undefined || sideAssignment === undefined) {
@@ -551,6 +560,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     reselect() {
       requestGeneration += 1;
       openGeneration += 1;
+      invalidateDeviceRefresh();
       stopCurrentStreams();
       update({
         screen: "deviceSelection",
@@ -565,7 +575,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     destroy() {
       requestGeneration += 1;
       openGeneration += 1;
-      deviceRefreshGeneration += 1;
+      invalidateDeviceRefresh();
       permissionGranted = false;
       stopCurrentStreams();
       listeners.clear();

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -5,6 +5,7 @@ import {
   createDevicePinnedStream,
   type DevicePinnedStream
 } from "../camera/createDevicePinnedStream";
+import { createReconnectBudget } from "../camera/reconnectPolicy";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,7 +32,8 @@ export type WorkbenchErrorKind =
   | "enumerationFailed"
   | "cameraConstraintFailed"
   | "cameraOpenFailed"
-  | "distinctDevicesRequired";
+  | "distinctDevicesRequired"
+  | "reconnectCooldown";
 
 export interface WorkbenchError {
   readonly kind: WorkbenchErrorKind;
@@ -68,10 +70,8 @@ export interface DiagnosticWorkbench {
   getState(): WorkbenchState;
   subscribe(listener: StateListener): () => void;
   requestPermission(): Promise<void>;
-  assignDevices(
-    frontDeviceId: string,
-    sideDeviceId: string
-  ): Promise<void>;
+  assignDevices(frontDeviceId: string, sideDeviceId: string): Promise<void>;
+  refreshDevicesFromDeviceChange(): Promise<void>;
   swapRoles(): Promise<void>;
   reselect(): void;
   destroy(): void;
@@ -89,8 +89,10 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   };
 
   const listeners = new Set<StateListener>();
+  const reconnectBudget = createReconnectBudget();
   let openGeneration = 0;
   let requestGeneration = 0;
+  let deviceRefreshGeneration = 0;
 
   const emit = (): void => {
     for (const fn of listeners) {
@@ -115,10 +117,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     stopStreams(state.frontStream, state.sideStream);
   };
 
-  const labelFor = (
-    devices: MediaDeviceInfo[],
-    deviceId: string
-  ): string => {
+  const labelFor = (devices: MediaDeviceInfo[], deviceId: string): string => {
     const foundIndex = devices.findIndex((d) => d.deviceId === deviceId);
     const found = foundIndex >= 0 ? devices[foundIndex] : undefined;
 
@@ -137,7 +136,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           title: "このブラウザではカメラを使用できません",
           cause: "navigator.mediaDevices.getUserMedia が利用できません。",
           impact: "フロント・サイド両方のキャプチャが開始できません。",
-          reproduction: "カメラ API 非対応のブラウザまたは非 HTTPS 相当の環境で診断ワークベンチを開いてください。",
+          reproduction:
+            "カメラ API 非対応のブラウザまたは非 HTTPS 相当の環境で診断ワークベンチを開いてください。",
           nextAction: "Chrome の安全なローカル開発 URL で開き直してください。"
         };
       case "permissionDenied":
@@ -147,16 +147,20 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           cause: "ブラウザのカメラ権限が拒否されました。",
           impact: "フロント・サイド両方のキャプチャが開始できません。",
           reproduction: "リロードしてカメラ権限を拒否してください。",
-          nextAction: "ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。"
+          nextAction:
+            "ブラウザのサイト設定でカメラ権限を許可し、リトライしてください。"
         };
       case "permissionFailed":
         return {
           kind,
           title: "カメラ許可を確認できません",
           cause: "許可確認用の getUserMedia が失敗しました。",
-          impact: "カメラ許可が完了せず、フロント・サイド両方のキャプチャ準備に進めません。",
-          reproduction: "カメラ許可操作後にブラウザまたは OS がカメラ開始を中断する状態でリトライしてください。",
-          nextAction: "カメラ接続、OS のカメラ権限、他アプリの使用状況を確認してからリトライしてください。"
+          impact:
+            "カメラ許可が完了せず、フロント・サイド両方のキャプチャ準備に進めません。",
+          reproduction:
+            "カメラ許可操作後にブラウザまたは OS がカメラ開始を中断する状態でリトライしてください。",
+          nextAction:
+            "カメラ接続、OS のカメラ権限、他アプリの使用状況を確認してからリトライしてください。"
         };
       case "cameraNotFound":
         return {
@@ -165,7 +169,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           cause: "ブラウザが video input device を検出できませんでした。",
           impact: "フロント・サイド両方のキャプチャが開始できません。",
           reproduction: "カメラを接続せずに診断ワークベンチを開いてください。",
-          nextAction: "カメラ接続と OS のカメラ権限を確認してからリトライしてください。"
+          nextAction:
+            "カメラ接続と OS のカメラ権限を確認してからリトライしてください。"
         };
       case "enumerationFailed":
         return {
@@ -173,17 +178,21 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           title: "カメラ一覧を取得できません",
           cause: "navigator.mediaDevices.enumerateDevices が失敗しました。",
           impact: "フロント・サイドの割り当て画面を表示できません。",
-          reproduction: "カメラ許可後にデバイス列挙が失敗するブラウザ状態でリトライしてください。",
-          nextAction: "ブラウザのカメラ権限と接続状態を確認し、ページをリロードしてください。"
+          reproduction:
+            "カメラ許可後にデバイス列挙が失敗するブラウザ状態でリトライしてください。",
+          nextAction:
+            "ブラウザのカメラ権限と接続状態を確認し、ページをリロードしてください。"
         };
       case "cameraConstraintFailed":
         return {
           kind,
           title: "選択したカメラを現在の条件で開始できません",
-          cause: "選択した capture constraints がデバイスでサポートされていません。",
+          cause:
+            "選択した capture constraints がデバイスでサポートされていません。",
           impact: "該当 lane の capture を開始できません。",
           reproduction: "現在の設定で同じカメラを選択してください。",
-          nextAction: "別のカメラを再選択するか、PoC の既定条件でリトライしてください。"
+          nextAction:
+            "別のカメラを再選択するか、PoC の既定条件でリトライしてください。"
         };
       case "cameraOpenFailed":
         return {
@@ -192,7 +201,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           cause: "getUserMedia がカメラ開始中に失敗しました。",
           impact: "選択した2台の live preview を開始できません。",
           reproduction: "同じカメラ割り当てで確定を押してください。",
-          nextAction: "カメラが他のアプリで使用中でないか確認し、再選択してください。"
+          nextAction:
+            "カメラが他のアプリで使用中でないか確認し、再選択してください。"
         };
       case "distinctDevicesRequired":
         return {
@@ -200,8 +210,18 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           title: "別々のカメラを選択してください",
           cause: "フロントとサイドに同じ deviceId が選択されました。",
           impact: "v2 の side trigger 設計を検証できません。",
-          reproduction: "フロントとサイドで同じカメラを選び、確定してください。",
+          reproduction:
+            "フロントとサイドで同じカメラを選び、確定してください。",
           nextAction: "フロントとサイドに異なるカメラを選択してください。"
+        };
+      case "reconnectCooldown":
+        return {
+          kind,
+          title: "少し待ってからもう一度お試しください",
+          cause: "短時間にカメラ開始の失敗が続きました。",
+          impact: "カメラ開始の連続試行を一時的に止めています。",
+          reproduction: "同じ割り当てでカメラ開始失敗を繰り返してください。",
+          nextAction: "1秒ほど待ってから再選択してください。"
         };
     }
   };
@@ -225,6 +245,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       case "cameraOpenFailed":
         return error.kind;
       case "distinctDevicesRequired":
+      case "reconnectCooldown":
         return state.screen;
     }
   };
@@ -247,11 +268,29 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     }
   };
 
+  const screenForDevices = (
+    devices: readonly MediaDeviceInfo[]
+  ): WorkbenchScreen => {
+    if (devices.length === 0) {
+      return "cameraNotFound";
+    }
+
+    return devices.length === 1 ? "singleCamera" : "deviceSelection";
+  };
+
   const openStreams = async (
     frontId: string,
     sideId: string,
     preservePreviewOnFailure: boolean
   ): Promise<void> => {
+    const reconnectKey = `${frontId}:${sideId}`;
+    const nowMs = Date.now();
+
+    if (!reconnectBudget.canAttempt(reconnectKey, nowMs)) {
+      update({ error: createError("reconnectCooldown") });
+      return;
+    }
+
     openGeneration += 1;
     const myGeneration = openGeneration;
     const previousFrontStream = state.frontStream;
@@ -296,6 +335,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         sideStream,
         error: undefined
       });
+      reconnectBudget.recordSuccess(reconnectKey);
     } catch (error: unknown) {
       stopStreams(...openedStreams);
 
@@ -304,6 +344,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       }
 
       const workbenchError = classifyOpenError(error);
+      reconnectBudget.recordFailure(reconnectKey, Date.now());
 
       if (
         preservePreviewOnFailure &&
@@ -324,6 +365,55 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         error: workbenchError
       });
     }
+  };
+
+  const updatePreviewDevices = (devices: MediaDeviceInfo[]): void => {
+    update({
+      devices,
+      frontAssignment:
+        state.frontAssignment === undefined
+          ? undefined
+          : {
+              ...state.frontAssignment,
+              label: labelFor(devices, state.frontAssignment.deviceId)
+            },
+      sideAssignment:
+        state.sideAssignment === undefined
+          ? undefined
+          : {
+              ...state.sideAssignment,
+              label: labelFor(devices, state.sideAssignment.deviceId)
+            },
+      error: undefined
+    });
+  };
+
+  const applyDeviceRefreshFailure = (): void => {
+    const error = createError("enumerationFailed");
+
+    if (state.screen === "previewing") {
+      update({ error });
+      return;
+    }
+
+    update({ screen: "enumerationFailed", error });
+  };
+
+  const applyDeviceRefreshSuccess = (devices: MediaDeviceInfo[]): void => {
+    if (state.screen === "previewing") {
+      updatePreviewDevices(devices);
+      return;
+    }
+
+    const nextScreen = screenForDevices(devices);
+    update({
+      screen: nextScreen,
+      devices,
+      error:
+        nextScreen === "cameraNotFound"
+          ? createError("cameraNotFound")
+          : undefined
+    });
   };
 
   return {
@@ -405,7 +495,39 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
-      await openStreams(frontDeviceId, sideDeviceId, state.screen === "previewing");
+      await openStreams(
+        frontDeviceId,
+        sideDeviceId,
+        state.screen === "previewing"
+      );
+    },
+
+    async refreshDevicesFromDeviceChange() {
+      if (state.screen === "permission") {
+        return;
+      }
+
+      deviceRefreshGeneration += 1;
+      const myGeneration = deviceRefreshGeneration;
+
+      let devices: MediaDeviceInfo[];
+
+      try {
+        devices = await enumerateVideoDevices();
+      } catch {
+        if (myGeneration !== deviceRefreshGeneration) {
+          return;
+        }
+
+        applyDeviceRefreshFailure();
+        return;
+      }
+
+      if (myGeneration !== deviceRefreshGeneration) {
+        return;
+      }
+
+      applyDeviceRefreshSuccess(devices);
     },
 
     async swapRoles() {
@@ -439,6 +561,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     destroy() {
       requestGeneration += 1;
       openGeneration += 1;
+      deviceRefreshGeneration += 1;
       stopCurrentStreams();
       listeners.clear();
     }

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -130,15 +130,22 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     stopStreams(state.frontStream, state.sideStream);
   };
 
-  const labelFor = (devices: MediaDeviceInfo[], deviceId: string): string => {
+  const labelFor = (
+    devices: MediaDeviceInfo[],
+    deviceId: string
+  ): string | undefined => {
     const foundIndex = devices.findIndex((d) => d.deviceId === deviceId);
     const found = foundIndex >= 0 ? devices[foundIndex] : undefined;
+
+    if (foundIndex < 0) {
+      return undefined;
+    }
 
     if (found !== undefined && found.label !== "") {
       return found.label;
     }
 
-    return foundIndex >= 0 ? `Camera ${String(foundIndex + 1)}` : "Camera";
+    return `Camera ${String(foundIndex + 1)}`;
   };
 
   const createError = (kind: WorkbenchErrorKind): WorkbenchError => {
@@ -327,8 +334,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
-      const frontLabel = labelFor(state.devices, frontId);
-      const sideLabel = labelFor(state.devices, sideId);
+      const frontLabel = labelFor(state.devices, frontId) ?? "Camera";
+      const sideLabel = labelFor(state.devices, sideId) ?? "Camera";
 
       stopStreams(previousFrontStream, previousSideStream);
 
@@ -388,14 +395,18 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
           ? undefined
           : {
               ...state.frontAssignment,
-              label: labelFor(devices, state.frontAssignment.deviceId)
+              label:
+                labelFor(devices, state.frontAssignment.deviceId) ??
+                state.frontAssignment.label
             },
       sideAssignment:
         state.sideAssignment === undefined
           ? undefined
           : {
               ...state.sideAssignment,
-              label: labelFor(devices, state.sideAssignment.deviceId)
+              label:
+                labelFor(devices, state.sideAssignment.deviceId) ??
+                state.sideAssignment.label
             },
       error: undefined
     });
@@ -605,14 +616,18 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       invalidateDeviceRefresh();
       permissionEnumerationGeneration = undefined;
       pendingDeviceRefreshAfterPermission = false;
+      const nextScreen = screenForDevices(state.devices);
       stopCurrentStreams();
       update({
-        screen: "deviceSelection",
+        screen: nextScreen,
         frontAssignment: undefined,
         sideAssignment: undefined,
         frontStream: undefined,
         sideStream: undefined,
-        error: undefined
+        error:
+          nextScreen === "cameraNotFound"
+            ? createError("cameraNotFound")
+            : undefined
       });
     },
 

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -94,9 +94,17 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
   let requestGeneration = 0;
   let deviceRefreshGeneration = 0;
   let permissionGranted = false;
+  let permissionEnumerationGeneration: number | undefined;
+  let pendingDeviceRefreshAfterPermission = false;
 
   const invalidateDeviceRefresh = (): void => {
     deviceRefreshGeneration += 1;
+  };
+
+  const finishPermissionEnumeration = (generation: number): void => {
+    if (permissionEnumerationGeneration === generation) {
+      permissionEnumerationGeneration = undefined;
+    }
   };
 
   const emit = (): void => {
@@ -288,6 +296,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     sideId: string,
     preservePreviewOnFailure: boolean
   ): Promise<void> => {
+    openGeneration += 1;
+    const myGeneration = openGeneration;
     const reconnectKey = JSON.stringify([frontId, sideId]);
     const nowMs = Date.now();
 
@@ -296,8 +306,6 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       return;
     }
 
-    openGeneration += 1;
-    const myGeneration = openGeneration;
     const previousFrontStream = state.frontStream;
     const previousSideStream = state.sideStream;
     const openedStreams: DevicePinnedStream[] = [];
@@ -421,6 +429,48 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
     });
   };
 
+  const refreshDevicesFromDeviceChange = async (): Promise<void> => {
+    if (!permissionGranted) {
+      if (permissionEnumerationGeneration !== undefined) {
+        pendingDeviceRefreshAfterPermission = true;
+      }
+      return;
+    }
+
+    invalidateDeviceRefresh();
+    const myGeneration = deviceRefreshGeneration;
+
+    let devices: MediaDeviceInfo[];
+
+    try {
+      devices = await enumerateVideoDevices();
+    } catch {
+      if (myGeneration !== deviceRefreshGeneration) {
+        return;
+      }
+
+      applyDeviceRefreshFailure();
+      return;
+    }
+
+    if (myGeneration !== deviceRefreshGeneration) {
+      return;
+    }
+
+    applyDeviceRefreshSuccess(devices);
+  };
+
+  const applyPendingDeviceRefreshAfterPermission =
+    async (): Promise<boolean> => {
+      if (!pendingDeviceRefreshAfterPermission) {
+        return false;
+      }
+
+      pendingDeviceRefreshAfterPermission = false;
+      await refreshDevicesFromDeviceChange();
+      return true;
+    };
+
   return {
     getState() {
       return state;
@@ -438,6 +488,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       openGeneration += 1;
       invalidateDeviceRefresh();
       permissionGranted = false;
+      permissionEnumerationGeneration = undefined;
+      pendingDeviceRefreshAfterPermission = false;
       const myGeneration = requestGeneration;
 
       stopCurrentStreams();
@@ -464,14 +516,22 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
-      permissionGranted = true;
-
       let devices: MediaDeviceInfo[];
+
+      permissionEnumerationGeneration = myGeneration;
 
       try {
         devices = await enumerateVideoDevices();
       } catch {
+        finishPermissionEnumeration(myGeneration);
+
         if (myGeneration !== requestGeneration) {
+          return;
+        }
+
+        permissionGranted = true;
+
+        if (await applyPendingDeviceRefreshAfterPermission()) {
           return;
         }
 
@@ -480,7 +540,15 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
         return;
       }
 
+      finishPermissionEnumeration(myGeneration);
+
       if (myGeneration !== requestGeneration) {
+        return;
+      }
+
+      permissionGranted = true;
+
+      if (await applyPendingDeviceRefreshAfterPermission()) {
         return;
       }
 
@@ -513,33 +581,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       );
     },
 
-    async refreshDevicesFromDeviceChange() {
-      if (!permissionGranted) {
-        return;
-      }
-
-      invalidateDeviceRefresh();
-      const myGeneration = deviceRefreshGeneration;
-
-      let devices: MediaDeviceInfo[];
-
-      try {
-        devices = await enumerateVideoDevices();
-      } catch {
-        if (myGeneration !== deviceRefreshGeneration) {
-          return;
-        }
-
-        applyDeviceRefreshFailure();
-        return;
-      }
-
-      if (myGeneration !== deviceRefreshGeneration) {
-        return;
-      }
-
-      applyDeviceRefreshSuccess(devices);
-    },
+    refreshDevicesFromDeviceChange,
 
     async swapRoles() {
       invalidateDeviceRefresh();
@@ -561,6 +603,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       requestGeneration += 1;
       openGeneration += 1;
       invalidateDeviceRefresh();
+      permissionEnumerationGeneration = undefined;
+      pendingDeviceRefreshAfterPermission = false;
       stopCurrentStreams();
       update({
         screen: "deviceSelection",
@@ -577,6 +621,8 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       openGeneration += 1;
       invalidateDeviceRefresh();
       permissionGranted = false;
+      permissionEnumerationGeneration = undefined;
+      pendingDeviceRefreshAfterPermission = false;
       stopCurrentStreams();
       listeners.clear();
     }

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -98,8 +98,14 @@ interface LiveLandmarkInspection {
 
 interface ActiveTracking {
   readonly key: string;
-  readonly frontVideo: HTMLVideoElement;
-  readonly sideVideo: HTMLVideoElement;
+  frontVideo: HTMLVideoElement;
+  sideVideo: HTMLVideoElement;
+  bindVideos(frontVideo: HTMLVideoElement, sideVideo: HTMLVideoElement): void;
+  stop(): void;
+}
+
+interface LaneTracking {
+  bindVideo(video: HTMLVideoElement): void;
   stop(): void;
 }
 
@@ -489,9 +495,8 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     }
   };
 
-  const startLaneTracking = (
-    options: LaneTrackingOptions
-  ): { stop(): void } => {
+  const startLaneTracking = (options: LaneTrackingOptions): LaneTracking => {
+    let video = options.video;
     let stopped = false;
     let cleanupStarted = false;
     let callbackId: number | undefined;
@@ -516,9 +521,9 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     const cancelScheduledFrame = (): void => {
       if (
         callbackId !== undefined &&
-        typeof options.video.cancelVideoFrameCallback === "function"
+        typeof video.cancelVideoFrameCallback === "function"
       ) {
-        options.video.cancelVideoFrameCallback(callbackId);
+        video.cancelVideoFrameCallback(callbackId);
         callbackId = undefined;
       }
 
@@ -537,7 +542,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       const context = frameCalibrationContext();
       setLaneTimestamp(options.role, timestamp);
 
-      if (!videoReadyForBitmap(options.video)) {
+      if (!videoReadyForBitmap(video)) {
         schedule();
         return;
       }
@@ -564,7 +569,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
         const laneDetection = await runLaneDetection(
           tracker,
-          options,
+          { ...options, video },
           timestamp
         );
 
@@ -577,7 +582,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
           options.role,
           laneDetection,
           timestamp,
-          options.video,
+          video,
           context
         );
       } catch (error: unknown) {
@@ -599,8 +604,8 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
         return;
       }
 
-      if (typeof options.video.requestVideoFrameCallback === "function") {
-        callbackId = options.video.requestVideoFrameCallback(
+      if (typeof video.requestVideoFrameCallback === "function") {
+        callbackId = video.requestVideoFrameCallback(
           (_now, metadata) => {
             void processFrame(metadata);
           }
@@ -682,6 +687,15 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     schedule();
 
     return {
+      bindVideo(nextVideo) {
+        if (stopped || nextVideo === video) {
+          return;
+        }
+
+        cancelScheduledFrame();
+        video = nextVideo;
+        schedule();
+      },
       stop() {
         stopLane();
       }
@@ -764,13 +778,13 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       return;
     }
 
-    const key = `${state.frontStream.stream.id}:${state.sideStream.stream.id}`;
+    const key = JSON.stringify([
+      [state.frontStream.deviceId, state.frontStream.stream.id],
+      [state.sideStream.deviceId, state.sideStream.stream.id]
+    ]);
 
-    if (
-      activeTracking?.key === key &&
-      activeTracking.frontVideo === frontVideo &&
-      activeTracking.sideVideo === sideVideo
-    ) {
+    if (activeTracking?.key === key) {
+      activeTracking.bindVideos(frontVideo, sideVideo);
       return;
     }
 
@@ -799,15 +813,22 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       streamId: state.sideStream.stream.id
     });
 
-    activeTracking = {
+    const tracking: ActiveTracking = {
       key,
       frontVideo,
       sideVideo,
+      bindVideos(nextFrontVideo, nextSideVideo) {
+        frontLane.bindVideo(nextFrontVideo);
+        sideLane.bindVideo(nextSideVideo);
+        tracking.frontVideo = nextFrontVideo;
+        tracking.sideVideo = nextSideVideo;
+      },
       stop() {
         frontLane.stop();
         sideLane.stop();
       }
     };
+    activeTracking = tracking;
   };
 
   return {

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -502,6 +502,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     let callbackId: number | undefined;
     let timeoutId: number | undefined;
     let trackerPromise: Promise<MediaPipeHandTracker> | undefined;
+    let videoGeneration = 0;
     const trackEndedObserver: { current?: { stop(): void } } = {};
 
     setLaneHealth(options.role, "capturing");
@@ -534,6 +535,14 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     };
 
     const processFrame = async (metadata: FrameTimingLike): Promise<void> => {
+      const frameVideoGeneration = videoGeneration;
+
+      const scheduleIfCurrentVideo = (): void => {
+        if (frameVideoGeneration === videoGeneration) {
+          schedule();
+        }
+      };
+
       if (isStopped()) {
         return;
       }
@@ -543,7 +552,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       setLaneTimestamp(options.role, timestamp);
 
       if (!videoReadyForBitmap(video)) {
-        schedule();
+        scheduleIfCurrentVideo();
         return;
       }
 
@@ -592,11 +601,11 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
         console.error("Diagnostic lane tracking failed", error);
         setLaneHealth(options.role, "failed");
-        schedule();
+        scheduleIfCurrentVideo();
         return;
       }
 
-      schedule();
+      scheduleIfCurrentVideo();
     };
 
     const schedule = (): void => {
@@ -694,6 +703,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
 
         cancelScheduledFrame();
         video = nextVideo;
+        videoGeneration += 1;
         schedule();
       },
       stop() {

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -1,4 +1,5 @@
 import { createFrameTimestamp } from "../camera/frameTimestamp";
+import { observeTrackEnded } from "../camera/observeTrackEnded";
 import {
   createMediaPipeHandTracker,
   type MediaPipeHandTracker
@@ -57,7 +58,10 @@ import { renderFusionPanel } from "./renderFusionPanel";
 import { renderSideTriggerCalibrationControls } from "./renderSideTriggerCalibrationControls";
 import { renderSideTriggerPanel } from "./renderSideTriggerPanel";
 import { renderSideWorldLandmarks } from "./renderWorldLandmarks";
-import type { WorkbenchInspectionState } from "./renderWorkbench";
+import {
+  formatLaneHealthLabel,
+  type WorkbenchInspectionState
+} from "./renderWorkbench";
 import { formatFrameTimestamp } from "./timestampFormat";
 
 interface FrameTimingLike {
@@ -69,6 +73,7 @@ interface FrameTimingLike {
 interface LaneTrackingOptions {
   readonly role: "frontAim" | "sideTrigger";
   readonly video: HTMLVideoElement;
+  readonly stream: MediaStream;
   readonly deviceId: string;
   readonly streamId: string;
 }
@@ -266,7 +271,9 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   let frontAimMapper = createFrontAimMapper();
   let sideTriggerMapper: SideTriggerMapper = createSideTriggerMapper();
   let inputFusionMapper: InputFusionMapper = createInputFusionMapper();
-  let syncedScreen: WorkbenchState["screen"] | undefined;
+  let lastPreviewDeviceIds:
+    | { readonly frontDeviceId: string; readonly sideDeviceId: string }
+    | undefined;
 
   const setInspection = (patch: Partial<WorkbenchInspectionState>): void => {
     inspectionState = { ...inspectionState, ...patch };
@@ -274,8 +281,14 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   };
 
   const updateDom = (): void => {
-    updateText("wb-front-health", `health: ${inspectionState.frontLaneHealth}`);
-    updateText("wb-side-health", `health: ${inspectionState.sideLaneHealth}`);
+    updateText(
+      "wb-front-health",
+      `health: ${formatLaneHealthLabel(inspectionState.frontLaneHealth)}`
+    );
+    updateText(
+      "wb-side-health",
+      `health: ${formatLaneHealthLabel(inspectionState.sideLaneHealth)}`
+    );
     updateText(
       "wb-front-timestamp",
       formatFrameTimestamp(
@@ -382,6 +395,12 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     tuning: context.fusionTuning
   });
 
+  const timestampNow = (): FrameTimestamp => {
+    const now = performance.now();
+
+    return createFrameTimestamp({ expectedDisplayTime: now }, now);
+  };
+
   const setLaneDetection = (
     role: LaneTrackingOptions["role"],
     detection: FrontHandDetection | SideHandDetection | undefined,
@@ -478,6 +497,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     let callbackId: number | undefined;
     let timeoutId: number | undefined;
     let trackerPromise: Promise<MediaPipeHandTracker> | undefined;
+    const trackEndedObserver: { current?: { stop(): void } } = {};
 
     setLaneHealth(options.role, "capturing");
 
@@ -492,6 +512,21 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     };
 
     const isStopped = (): boolean => stopped;
+
+    const cancelScheduledFrame = (): void => {
+      if (
+        callbackId !== undefined &&
+        typeof options.video.cancelVideoFrameCallback === "function"
+      ) {
+        options.video.cancelVideoFrameCallback(callbackId);
+        callbackId = undefined;
+      }
+
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
 
     const processFrame = async (metadata: FrameTimingLike): Promise<void> => {
       if (isStopped()) {
@@ -591,24 +626,64 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
         });
     };
 
+    const updateLaneUnavailableForCaptureLoss = (): void => {
+      const context = frameCalibrationContext();
+      const timestamp = timestampNow();
+      const fusionResult =
+        options.role === "frontAim"
+          ? inputFusionMapper.updateAimUnavailable(timestamp, {
+              ...currentFusionContext(context),
+              frontLaneHealth: "captureLost"
+            })
+          : inputFusionMapper.updateTriggerUnavailable(timestamp, {
+              ...currentFusionContext(context),
+              sideLaneHealth: "captureLost"
+            });
+
+      setInspection(
+        options.role === "frontAim"
+          ? {
+              frontLaneHealth: "captureLost",
+              frontDetection: undefined,
+              frontAimFrame: undefined,
+              frontAimTelemetry: undefined,
+              frontFrameTimestamp: timestamp,
+              fusionFrame: fusionResult.fusedFrame,
+              fusionTelemetry: fusionResult.telemetry
+            }
+          : {
+              sideLaneHealth: "captureLost",
+              sideDetection: undefined,
+              sideTriggerFrame: undefined,
+              sideTriggerTelemetry: undefined,
+              sideFrameTimestamp: timestamp,
+              fusionFrame: fusionResult.fusedFrame,
+              fusionTelemetry: fusionResult.telemetry
+            }
+      );
+    };
+
+    const stopLane = (): void => {
+      stopped = true;
+      cancelScheduledFrame();
+      trackEndedObserver.current?.stop();
+      cleanupTracker();
+    };
+
+    trackEndedObserver.current = observeTrackEnded(options.stream, () => {
+      if (stopped) {
+        return;
+      }
+
+      stopLane();
+      updateLaneUnavailableForCaptureLoss();
+    });
+
     schedule();
 
     return {
       stop() {
-        stopped = true;
-
-        if (
-          callbackId !== undefined &&
-          typeof options.video.cancelVideoFrameCallback === "function"
-        ) {
-          options.video.cancelVideoFrameCallback(callbackId);
-        }
-
-        if (timeoutId !== undefined) {
-          window.clearTimeout(timeoutId);
-        }
-
-        cleanupTracker();
+        stopLane();
       }
     };
   };
@@ -644,20 +719,39 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     activeTracking = undefined;
   };
 
-  const sync = (state: WorkbenchState): void => {
-    const previousScreen = syncedScreen;
-    syncedScreen = state.screen;
+  const deviceIdsFor = (
+    state: WorkbenchState
+  ):
+    | { readonly frontDeviceId: string; readonly sideDeviceId: string }
+    | undefined => {
+    if (state.frontStream === undefined || state.sideStream === undefined) {
+      return undefined;
+    }
 
+    return {
+      frontDeviceId: state.frontStream.deviceId,
+      sideDeviceId: state.sideStream.deviceId
+    };
+  };
+
+  const deviceIdsChanged = (
+    previous:
+      | { readonly frontDeviceId: string; readonly sideDeviceId: string }
+      | undefined,
+    next: { readonly frontDeviceId: string; readonly sideDeviceId: string }
+  ): boolean =>
+    previous !== undefined &&
+    (previous.frontDeviceId !== next.frontDeviceId ||
+      previous.sideDeviceId !== next.sideDeviceId);
+
+  const sync = (state: WorkbenchState): void => {
     if (
       state.screen !== "previewing" ||
       state.frontStream === undefined ||
       state.sideStream === undefined
     ) {
       stopActiveTracking();
-      resetTrackingState({
-        resetCalibration:
-          previousScreen === "previewing" && state.screen === "deviceSelection"
-      });
+      resetTrackingState();
       return;
     }
 
@@ -681,17 +775,26 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     }
 
     stopActiveTracking();
-    resetTrackingState();
+    const nextDeviceIds = deviceIdsFor(state);
+    resetTrackingState({
+      resetCalibration:
+        nextDeviceIds === undefined
+          ? false
+          : deviceIdsChanged(lastPreviewDeviceIds, nextDeviceIds)
+    });
+    lastPreviewDeviceIds = nextDeviceIds;
 
     const frontLane = startLaneTracking({
       role: "frontAim",
       video: frontVideo,
+      stream: state.frontStream.stream,
       deviceId: state.frontStream.deviceId,
       streamId: state.frontStream.stream.id
     });
     const sideLane = startLaneTracking({
       role: "sideTrigger",
       video: sideVideo,
+      stream: state.sideStream.stream,
       deviceId: state.sideStream.deviceId,
       streamId: state.sideStream.stream.id
     });
@@ -802,7 +905,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     destroy() {
       stopActiveTracking();
       resetTrackingState({ resetCalibration: true });
-      syncedScreen = undefined;
+      lastPreviewDeviceIds = undefined;
     }
   };
 };

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -8,10 +8,7 @@ import type {
   FusedGameInputFrame,
   FusionTelemetry
 } from "../../shared/types/fusion";
-import type {
-  AimInputFrame,
-  FrontAimTelemetry
-} from "../../shared/types/aim";
+import type { AimInputFrame, FrontAimTelemetry } from "../../shared/types/aim";
 import type {
   FrontHandDetection,
   SideHandDetection
@@ -20,10 +17,7 @@ import type {
   SideTriggerTelemetry,
   TriggerInputFrame
 } from "../../shared/types/trigger";
-import {
-  defaultFusionTuning,
-  type FusionTuning
-} from "../input-fusion";
+import { defaultFusionTuning, type FusionTuning } from "../input-fusion";
 import {
   defaultFrontAimCalibration,
   type FrontAimCalibration
@@ -190,6 +184,23 @@ const renderInspectionPane = (
   `;
 };
 
+export const formatLaneHealthLabel = (health: LaneHealthStatus): string => {
+  switch (health) {
+    case "captureLost":
+      return `${health} (カメラが切断されました)`;
+    case "failed":
+      return `${health} (カメラ処理に失敗しました)`;
+    case "stalled":
+      return `${health} (カメラ入力が停止しています)`;
+    case "notStarted":
+    case "waitingForPermission":
+    case "waitingForDeviceSelection":
+    case "capturing":
+    case "tracking":
+      return health;
+  }
+};
+
 const renderInspectionLane = (
   lanePrefix: "front" | "side",
   title: string,
@@ -201,7 +212,7 @@ const renderInspectionLane = (
   <section class="wb-preview-lane wb-inspection-lane">
     <h3>${title}</h3>
     <p class="wb-device-label">${escapeHTML(deviceLabel)}</p>
-    <p id="wb-${lanePrefix}-health" class="wb-lane-health">health: ${escapeHTML(health)}</p>
+    <p id="wb-${lanePrefix}-health" class="wb-lane-health">health: ${escapeHTML(formatLaneHealthLabel(health))}</p>
     <p id="wb-${lanePrefix}-timestamp" class="wb-timestamp-readout">${escapeHTML(formatFrameTimestamp(timestamp))}</p>
     <div class="wb-inspection-panes">
       ${renderInspectionPane(lanePrefix, "raw")}

--- a/tests/e2e/diagnostic.smoke.spec.ts
+++ b/tests/e2e/diagnostic.smoke.spec.ts
@@ -14,12 +14,35 @@ const installFakeCameras = async (
 ): Promise<void> => {
   await page.addInitScript(
     ({ fakeDevices, fakeMode }) => {
+      let devices = fakeDevices;
+      const events = new EventTarget();
+
+      Object.defineProperty(window, "__setFakeCameraDevices", {
+        configurable: true,
+        value: (nextDevices: FakeCameraDevice[]) => {
+          devices = nextDevices;
+          events.dispatchEvent(new Event("devicechange"));
+        }
+      });
+
       Object.defineProperty(navigator, "mediaDevices", {
         configurable: true,
         value: {
+          addEventListener: (
+            type: string,
+            listener: EventListenerOrEventListenerObject
+          ) => {
+            events.addEventListener(type, listener);
+          },
+          removeEventListener: (
+            type: string,
+            listener: EventListenerOrEventListenerObject
+          ) => {
+            events.removeEventListener(type, listener);
+          },
           enumerateDevices: () =>
             Promise.resolve(
-              fakeDevices.map((device) => ({
+              devices.map((device) => ({
                 kind: "videoinput",
                 deviceId: device.deviceId,
                 label: device.label,
@@ -118,8 +141,22 @@ test("diagnostic workbench runs permission, device selection, previews, swap, an
     "Front Camera"
   );
 
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __setFakeCameraDevices: (devices: FakeCameraDevice[]) => void;
+      }
+    ).__setFakeCameraDevices([
+      { deviceId: "front-device-id", label: "Front Camera" },
+      { deviceId: "side-device-id", label: "Side Camera" },
+      { deviceId: "replugged-device-id", label: "Replugged Camera" }
+    ]);
+  });
   await page.getByRole("button", { name: "再選択" }).click();
   await expect(page.getByRole("heading", { name: "カメラ選択" })).toBeVisible();
+  await expect(page.locator("#wb-front-select")).toContainText(
+    "Replugged Camera"
+  );
 });
 
 test("diagnostic workbench shows permission denial details", async ({

--- a/tests/e2e/home.smoke.spec.ts
+++ b/tests/e2e/home.smoke.spec.ts
@@ -6,6 +6,7 @@ test("home page runs production balloon game flow without diagnostic surfaces", 
   await page.addInitScript(() => {
     const callbacks = new Map<number, FrameRequestCallback>();
     let nextFrameId = 1;
+    const tracksByDeviceId = new Map<string, MediaStreamTrack[]>();
 
     Object.defineProperty(window, "requestAnimationFrame", {
       configurable: true,
@@ -50,7 +51,37 @@ test("home page runs production balloon game flow without diagnostic surfaces", 
               toJSON: () => ({})
             }
           ]),
-        getUserMedia: () => Promise.resolve(new MediaStream())
+        getUserMedia: (constraints: MediaStreamConstraints) => {
+          const videoConstraints = constraints.video;
+          const requestedDeviceId =
+            typeof videoConstraints === "object" &&
+            typeof videoConstraints.deviceId === "object" &&
+            "exact" in videoConstraints.deviceId
+              ? String(videoConstraints.deviceId.exact)
+              : "front-device-id";
+          const canvas = document.createElement("canvas");
+          canvas.width = 2;
+          canvas.height = 2;
+          const track = canvas.captureStream(15).getVideoTracks()[0];
+          if (track === undefined) {
+            throw new Error("fake camera track was not created");
+          }
+
+          tracksByDeviceId.set(requestedDeviceId, [
+            ...(tracksByDeviceId.get(requestedDeviceId) ?? []),
+            track
+          ]);
+
+          return Promise.resolve(new MediaStream([track]));
+        }
+      }
+    });
+    Object.defineProperty(window, "__endFakeCameraTrack", {
+      configurable: true,
+      value: (deviceId: string) => {
+        const track = tracksByDeviceId.get(deviceId)?.at(-1);
+        track?.stop();
+        track?.dispatchEvent(new Event("ended"));
       }
     });
   });
@@ -60,7 +91,9 @@ test("home page runs production balloon game flow without diagnostic surfaces", 
   await expect(
     page.getByRole("heading", { name: "BalloonShoot v2" })
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "カメラを開始" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "カメラを開始" })
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: "diagnostic.html" })).toHaveCount(
     0
   );
@@ -96,16 +129,35 @@ test("home page runs production balloon game flow without diagnostic surfaces", 
 
   const baseNow = await page.evaluate(() => performance.now());
   await page.evaluate((nowMs) => {
-    (window as unknown as { __fireGameFrame: (now: number) => void }).__fireGameFrame(
-      nowMs
-    );
+    (
+      window as unknown as { __fireGameFrame: (now: number) => void }
+    ).__fireGameFrame(nowMs);
   }, baseNow + 4_000);
   await expect(page.locator("#game-hud")).toContainText("残り");
 
+  await page.evaluate(() => {
+    (
+      window as unknown as { __endFakeCameraTrack: (deviceId: string) => void }
+    ).__endFakeCameraTrack("front-device-id");
+  });
   await page.evaluate((nowMs) => {
-    (window as unknown as { __fireGameFrame: (now: number) => void }).__fireGameFrame(
-      nowMs
-    );
+    (
+      window as unknown as { __fireGameFrame: (now: number) => void }
+    ).__fireGameFrame(nowMs);
+  }, baseNow + 4_016);
+  await expect(page.locator("#game-hud")).toContainText(
+    "カメラが切断されました"
+  );
+  await expect(
+    page.getByRole("button", { name: "カメラを選び直す" })
+  ).toBeVisible();
+  await expect(page.locator("#game-hud")).not.toContainText("captureLost");
+  await expect(page.locator("#game-hud")).not.toContainText("laneFailed");
+
+  await page.evaluate((nowMs) => {
+    (
+      window as unknown as { __fireGameFrame: (now: number) => void }
+    ).__fireGameFrame(nowMs);
   }, baseNow + 64_000);
   await expect(page.getByRole("heading", { name: "結果" })).toBeVisible();
   await expect(page.getByRole("button", { name: "もう一度" })).toBeVisible();

--- a/tests/helpers/fakeTrack.ts
+++ b/tests/helpers/fakeTrack.ts
@@ -1,0 +1,35 @@
+export class FakeTrack {
+  readonly id: string;
+  readonly kind = "video";
+  readonly label: string;
+  readyState: MediaStreamTrackState = "live";
+  private readonly endedListeners = new Set<EventListener>();
+
+  constructor(id: string, label = id) {
+    this.id = id;
+    this.label = label;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.delete(listener);
+    }
+  }
+
+  fireEnded(): void {
+    this.readyState = "ended";
+    for (const listener of this.endedListeners) {
+      listener(new Event("ended"));
+    }
+  }
+
+  listenerCount(): number {
+    return this.endedListeners.size;
+  }
+}

--- a/tests/helpers/fakeTrack.ts
+++ b/tests/helpers/fakeTrack.ts
@@ -1,13 +1,18 @@
 export class FakeTrack {
   readonly id: string;
-  readonly kind = "video";
+  readonly kind: MediaStreamTrack["kind"];
   readonly label: string;
   readyState: MediaStreamTrackState = "live";
   private readonly endedListeners = new Set<EventListener>();
 
-  constructor(id: string, label = id) {
+  constructor(
+    id: string,
+    label = id,
+    kind: MediaStreamTrack["kind"] = "video"
+  ) {
     this.id = id;
     this.label = label;
+    this.kind = kind;
   }
 
   addEventListener(type: string, listener: EventListener): void {

--- a/tests/integration/balloonGameRuntime.test.ts
+++ b/tests/integration/balloonGameRuntime.test.ts
@@ -16,6 +16,7 @@ import {
   createAimFrame,
   createTriggerFrame
 } from "../unit/features/input-fusion/testFactory";
+import { FakeTrack } from "../helpers/fakeTrack";
 
 interface CapturedFusionContext {
   readonly method:
@@ -230,42 +231,6 @@ const createHandDetection = (): HandDetection => {
 
 interface FakePinnedStream extends DevicePinnedStream {
   readonly stopMock: ReturnType<typeof vi.fn>;
-}
-
-class FakeTrack {
-  readonly id: string;
-  readonly kind = "video";
-  readonly label: string;
-  readyState: MediaStreamTrackState = "live";
-  private readonly endedListeners = new Set<EventListener>();
-
-  constructor(id: string, label = id) {
-    this.id = id;
-    this.label = label;
-  }
-
-  addEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.endedListeners.add(listener);
-    }
-  }
-
-  removeEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.endedListeners.delete(listener);
-    }
-  }
-
-  fireEnded(): void {
-    this.readyState = "ended";
-    for (const listener of this.endedListeners) {
-      listener(new Event("ended"));
-    }
-  }
-
-  listenerCount(): number {
-    return this.endedListeners.size;
-  }
 }
 
 const createPinnedStream = (

--- a/tests/integration/balloonGameRuntime.test.ts
+++ b/tests/integration/balloonGameRuntime.test.ts
@@ -353,6 +353,53 @@ describe("createBalloonGameRuntime", () => {
     vi.unstubAllGlobals();
   });
 
+  it("logs tracker cleanup failures instead of leaking unhandled rejections", async () => {
+    vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });
+    const raf = createRaf();
+    const cleanupError = new Error("cleanup failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const tracker = createTracker();
+    const sideTracker = createTracker();
+    tracker.cleanupMock.mockRejectedValueOnce(cleanupError);
+    const createMediaPipeHandTracker = vi
+      .fn()
+      .mockResolvedValueOnce(tracker)
+      .mockResolvedValueOnce(sideTracker);
+    const runtime = createBalloonGameRuntime({
+      frontDeviceId: "front",
+      sideDeviceId: "side",
+      frontVideo: createVideo(),
+      sideVideo: createVideo(),
+      canvas: createCanvas(),
+      hudRoot: { innerHTML: "" } as HTMLElement,
+      nowMs: () => 0,
+      createAudioController: createAudio,
+      drawGameFrame: vi.fn(),
+      requestAnimationFrame: raf.requestAnimationFrame,
+      cancelAnimationFrame: raf.cancelAnimationFrame,
+      createDevicePinnedStream: (deviceId) =>
+        Promise.resolve(createPinnedStream(deviceId)),
+      createMediaPipeHandTracker
+    });
+
+    runtime.start();
+    await vi.waitFor(() => {
+      expect(createMediaPipeHandTracker).toHaveBeenCalledTimes(2);
+    });
+
+    runtime.destroy();
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[balloon game runtime] tracker cleanup failed",
+        cleanupError
+      );
+    });
+    vi.unstubAllGlobals();
+  });
+
   it("restores front lane health before fusing after a transient frame error", async () => {
     capturedFusionContexts.length = 0;
     vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });

--- a/tests/integration/balloonGameRuntime.test.ts
+++ b/tests/integration/balloonGameRuntime.test.ts
@@ -232,12 +232,55 @@ interface FakePinnedStream extends DevicePinnedStream {
   readonly stopMock: ReturnType<typeof vi.fn>;
 }
 
-const createPinnedStream = (deviceId: string): FakePinnedStream => {
+class FakeTrack {
+  readonly id: string;
+  readonly kind = "video";
+  readonly label: string;
+  readyState: MediaStreamTrackState = "live";
+  private readonly endedListeners = new Set<EventListener>();
+
+  constructor(id: string, label = id) {
+    this.id = id;
+    this.label = label;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.delete(listener);
+    }
+  }
+
+  fireEnded(): void {
+    this.readyState = "ended";
+    for (const listener of this.endedListeners) {
+      listener(new Event("ended"));
+    }
+  }
+
+  listenerCount(): number {
+    return this.endedListeners.size;
+  }
+}
+
+const createPinnedStream = (
+  deviceId: string,
+  tracks: readonly FakeTrack[] = []
+): FakePinnedStream => {
   const stopMock = vi.fn();
 
   return {
     deviceId,
-    stream: { id: `${deviceId}-stream` } as MediaStream,
+    stream: {
+      id: `${deviceId}-stream`,
+      getVideoTracks: vi.fn(() => [...tracks]),
+      getTracks: vi.fn(() => [...tracks])
+    } as unknown as MediaStream,
     stop: stopMock,
     stopMock
   };
@@ -724,6 +767,173 @@ describe("createBalloonGameRuntime", () => {
     expect(frontTracker.cleanupMock).toHaveBeenCalledOnce();
     expect(sideStream.stopMock).not.toHaveBeenCalled();
     expect(sideTracker.cleanupMock).not.toHaveBeenCalled();
+
+    runtime.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it("marks the front lane captureLost, clears fusion, and leaves side resources active when the front track ends", async () => {
+    capturedFusionContexts.length = 0;
+    vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });
+    const raf = createRaf();
+    const hudRoot = { innerHTML: "" } as HTMLElement;
+    const frontTrack = new FakeTrack("front-track");
+    const frontStream = createPinnedStream("front", [frontTrack]);
+    const sideStream = createPinnedStream("side", [
+      new FakeTrack("side-track")
+    ]);
+    const frontTracker = createTracker(() =>
+      Promise.resolve(createHandDetection())
+    );
+    const sideTracker = createTracker(() =>
+      Promise.resolve(createHandDetection())
+    );
+    const runtime = createBalloonGameRuntime({
+      frontDeviceId: "front",
+      sideDeviceId: "side",
+      frontVideo: createVideo(),
+      sideVideo: createVideo(),
+      canvas: createCanvas(),
+      hudRoot,
+      nowMs: () => 0,
+      createAudioController: createAudio,
+      drawGameFrame: vi.fn(),
+      requestAnimationFrame: raf.requestAnimationFrame,
+      cancelAnimationFrame: raf.cancelAnimationFrame,
+      createDevicePinnedStream: vi
+        .fn()
+        .mockResolvedValueOnce(frontStream)
+        .mockResolvedValueOnce(sideStream),
+      createMediaPipeHandTracker: vi
+        .fn()
+        .mockResolvedValueOnce(frontTracker)
+        .mockResolvedValueOnce(sideTracker)
+    });
+
+    runtime.start();
+    await vi.waitFor(() => {
+      expect(frontTrack.listenerCount()).toBe(1);
+    });
+    frontTrack.fireEnded();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.cleanupMock).toHaveBeenCalledOnce();
+    });
+    raf.fire(4_000);
+
+    expect(capturedFusionContexts.at(-1)).toMatchObject({
+      method: "updateAimUnavailable",
+      frontLaneHealth: "captureLost",
+      sideLaneHealth: "tracking"
+    });
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(sideStream.stopMock).not.toHaveBeenCalled();
+    expect(sideTracker.cleanupMock).not.toHaveBeenCalled();
+    expect(frontTrack.listenerCount()).toBe(0);
+    expect(hudRoot.innerHTML).toContain("カメラが切断されました");
+    expect(hudRoot.innerHTML).not.toContain("captureLost");
+
+    runtime.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it("retry after capture loss starts fresh lanes and clears the laneFailed context", async () => {
+    capturedFusionContexts.length = 0;
+    vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });
+    const raf = createRaf();
+    const frontVideo = createVideo();
+    const sideVideo = createVideo();
+    const oldFrontTrack = new FakeTrack("old-front-track");
+    const oldFrontStream = createPinnedStream("front", [oldFrontTrack]);
+    const oldSideStream = createPinnedStream("side", [
+      new FakeTrack("old-side-track")
+    ]);
+    const newFrontStream = createPinnedStream("front", [
+      new FakeTrack("new-front-track")
+    ]);
+    const newSideStream = createPinnedStream("side", [
+      new FakeTrack("new-side-track")
+    ]);
+    const restartedFrontDetect = vi.fn(() =>
+      Promise.resolve(createHandDetection())
+    );
+    const restartedSideDetect = vi.fn(() =>
+      Promise.resolve(createHandDetection())
+    );
+    const oldFrontTracker = createTracker();
+    const oldSideTracker = createTracker();
+    const newFrontTracker = createTracker(restartedFrontDetect);
+    const newSideTracker = createTracker(restartedSideDetect);
+    const runtime = createBalloonGameRuntime({
+      frontDeviceId: "front",
+      sideDeviceId: "side",
+      frontVideo,
+      sideVideo,
+      canvas: createCanvas(),
+      hudRoot: { innerHTML: "" } as HTMLElement,
+      nowMs: () => 0,
+      createAudioController: createAudio,
+      drawGameFrame: vi.fn(),
+      requestAnimationFrame: raf.requestAnimationFrame,
+      cancelAnimationFrame: raf.cancelAnimationFrame,
+      createDevicePinnedStream: vi
+        .fn()
+        .mockResolvedValueOnce(oldFrontStream)
+        .mockResolvedValueOnce(oldSideStream)
+        .mockResolvedValueOnce(newFrontStream)
+        .mockResolvedValueOnce(newSideStream),
+      createMediaPipeHandTracker: vi
+        .fn()
+        .mockResolvedValueOnce(oldFrontTracker)
+        .mockResolvedValueOnce(oldSideTracker)
+        .mockResolvedValueOnce(newFrontTracker)
+        .mockResolvedValueOnce(newSideTracker),
+      createImageBitmap: vi.fn(() =>
+        Promise.resolve({
+          width: 640,
+          height: 480,
+          close: vi.fn()
+        } as unknown as ImageBitmap)
+      )
+    });
+
+    runtime.start();
+    await vi.waitFor(() => {
+      expect(oldFrontTrack.listenerCount()).toBe(1);
+    });
+    oldFrontTrack.fireEnded();
+    await vi.waitFor(() => {
+      expect(oldFrontTracker.cleanupMock).toHaveBeenCalledOnce();
+    });
+
+    runtime.retry();
+    await vi.waitFor(() => {
+      expect(frontVideo.requestVideoFrameCallbackMock).toHaveBeenCalledTimes(2);
+      expect(sideVideo.requestVideoFrameCallbackMock).toHaveBeenCalledTimes(2);
+    });
+    expect(oldFrontTrack.listenerCount()).toBe(0);
+
+    frontVideo.fireFrame({ captureTime: 64_100, presentedFrames: 2 });
+    sideVideo.fireFrame({ captureTime: 64_100, presentedFrames: 2 });
+    await vi.waitFor(() => {
+      expect(restartedFrontDetect).toHaveBeenCalledOnce();
+      expect(restartedSideDetect).toHaveBeenCalledOnce();
+    });
+
+    expect(
+      capturedFusionContexts.filter(
+        (context) =>
+          context.method === "updateAimFrame" ||
+          context.method === "updateTriggerFrame"
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          frontLaneHealth: "tracking",
+          sideLaneHealth: "tracking"
+        })
+      ])
+    );
 
     runtime.destroy();
     vi.unstubAllGlobals();

--- a/tests/integration/diagnosticFusionWorkbench.test.ts
+++ b/tests/integration/diagnosticFusionWorkbench.test.ts
@@ -57,4 +57,39 @@ describe("diagnostic fusion workbench integration", () => {
       /<span>shot edge consumed<\/span>\s*<strong>true<\/strong>/
     );
   });
+
+  it("renders a device loss and recovery cycle through diagnostic fusion panels", () => {
+    const mapper = createInputFusionMapper();
+
+    mapper.updateAimFrame(createAimFrame(100), context);
+    const lost = mapper.updateTriggerUnavailable(
+      createTriggerFrame(112).timestamp,
+      {
+        ...context,
+        sideLaneHealth: "captureLost"
+      }
+    );
+    const lostHtml = renderFusionPanel(lost.fusedFrame, lost.telemetry);
+
+    expect(lostHtml).toMatch(
+      /<span>reject reason<\/span>\s*<strong>laneFailed<\/strong>/
+    );
+    expect(lostHtml).toMatch(
+      /<span>side lane health<\/span>\s*<strong>captureLost<\/strong>/
+    );
+
+    const recovered = mapper.updateTriggerFrame(
+      createTriggerFrame(116),
+      context
+    );
+    const recoveredHtml = renderFusionPanel(
+      recovered.fusedFrame,
+      recovered.telemetry
+    );
+
+    expect(recoveredHtml).toContain("pairedFrontAndSide");
+    expect(recoveredHtml).toMatch(
+      /<span>reject reason<\/span>\s*<strong>none<\/strong>/
+    );
+  });
 });

--- a/tests/unit/app/balloonGamePage.test.ts
+++ b/tests/unit/app/balloonGamePage.test.ts
@@ -11,6 +11,7 @@ const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
   }) as MediaDeviceInfo;
 
 const createRoot = () => {
+  let clickListener: ((event: Event) => void) | undefined;
   const elements = new Map<string, unknown>([
     ["#game-camera-feed-front", {} as HTMLVideoElement],
     ["#game-camera-feed-side", {} as HTMLVideoElement],
@@ -20,12 +21,25 @@ const createRoot = () => {
 
   return {
     innerHTML: "",
-    addEventListener: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: EventListener) => {
+      if (type === "click") {
+        clickListener = listener as (event: Event) => void;
+      }
+    }),
     removeEventListener: vi.fn(),
-    querySelector: vi.fn((selector: string) => elements.get(selector) ?? null)
+    querySelector: vi.fn((selector: string) => elements.get(selector) ?? null),
+    clickAction(action: string) {
+      clickListener?.({
+        target: {
+          getAttribute: (name: string) =>
+            name === "data-game-action" ? action : null
+        }
+      } as unknown as Event);
+    }
   } as unknown as HTMLElement & {
     innerHTML: string;
     querySelector: ReturnType<typeof vi.fn>;
+    clickAction(action: string): void;
   };
 };
 
@@ -119,5 +133,46 @@ describe("createBalloonGamePage", () => {
       })
     );
     expect(runtime.start).toHaveBeenCalledOnce();
+  });
+
+  it("reselects cameras from the running page while preserving available previous selections", async () => {
+    const root = createRoot();
+    const runtime = { start: vi.fn(), retry: vi.fn(), destroy: vi.fn() };
+    const enumerateVideoDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        createDevice("front", "Front Camera"),
+        createDevice("side", "Side Camera")
+      ])
+      .mockResolvedValueOnce([
+        createDevice("front", "Front Camera"),
+        createDevice("replacement", "Replacement Camera")
+      ]);
+    const page = createBalloonGamePage({
+      requestCameraPermission: vi.fn(() =>
+        Promise.resolve({ status: "granted" as const })
+      ),
+      enumerateVideoDevices,
+      createBalloonGameRuntime: vi.fn(() => runtime)
+    });
+
+    page.mount(root);
+    await page.requestCameraAccess();
+    page.selectCameras("front", "side");
+    root.clickAction("reselectCameras");
+
+    await vi.waitFor(() => {
+      expect(root.innerHTML).toContain("カメラ選択");
+      expect(root.innerHTML).toContain(
+        "切断されたカメラを選び直してください。"
+      );
+    });
+    expect(runtime.destroy).toHaveBeenCalledOnce();
+    expect(root.innerHTML).toMatch(
+      /<option value="front" selected>Front Camera<\/option>/
+    );
+    expect(root.innerHTML).toMatch(
+      /<option value="replacement" selected>Replacement Camera<\/option>/
+    );
   });
 });

--- a/tests/unit/app/balloonGamePage.test.ts
+++ b/tests/unit/app/balloonGamePage.test.ts
@@ -10,6 +10,17 @@ const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
     toJSON: () => ({})
   }) as MediaDeviceInfo;
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
 const createRoot = () => {
   let clickListener: ((event: Event) => void) | undefined;
   const elements = new Map<string, unknown>([
@@ -174,5 +185,85 @@ describe("createBalloonGamePage", () => {
     expect(root.innerHTML).toMatch(
       /<option value="replacement" selected>Replacement Camera<\/option>/
     );
+  });
+
+  it("keeps a still-present side camera in the side role when front is replaced", async () => {
+    const root = createRoot();
+    const runtime = { start: vi.fn(), retry: vi.fn(), destroy: vi.fn() };
+    const enumerateVideoDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        createDevice("front", "Front Camera"),
+        createDevice("side", "Side Camera")
+      ])
+      .mockResolvedValueOnce([
+        createDevice("side", "Side Camera"),
+        createDevice("replacement", "Replacement Camera")
+      ]);
+    const page = createBalloonGamePage({
+      requestCameraPermission: vi.fn(() =>
+        Promise.resolve({ status: "granted" as const })
+      ),
+      enumerateVideoDevices,
+      createBalloonGameRuntime: vi.fn(() => runtime)
+    });
+
+    page.mount(root);
+    await page.requestCameraAccess();
+    page.selectCameras("front", "side");
+    root.clickAction("reselectCameras");
+
+    await vi.waitFor(() => {
+      expect(root.innerHTML).toContain("カメラ選択");
+    });
+    expect(root.innerHTML).toMatch(
+      /id="front-camera-select"[\s\S]*<option value="side">Side Camera<\/option><option value="replacement" selected>Replacement Camera<\/option>/
+    );
+    expect(root.innerHTML).toMatch(
+      /id="side-camera-select"[\s\S]*<option value="side" selected>Side Camera<\/option><option value="replacement">Replacement Camera<\/option>/
+    );
+  });
+
+  it("ignores stale camera reselect results after a newer reselect completes", async () => {
+    const root = createRoot();
+    const runtime = { start: vi.fn(), retry: vi.fn(), destroy: vi.fn() };
+    const staleReselect = createDeferred<MediaDeviceInfo[]>();
+    const enumerateVideoDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        createDevice("front", "Front Camera"),
+        createDevice("side", "Side Camera")
+      ])
+      .mockReturnValueOnce(staleReselect.promise)
+      .mockResolvedValueOnce([
+        createDevice("front", "Front Camera"),
+        createDevice("fresh", "Fresh Camera")
+      ]);
+    const page = createBalloonGamePage({
+      requestCameraPermission: vi.fn(() =>
+        Promise.resolve({ status: "granted" as const })
+      ),
+      enumerateVideoDevices,
+      createBalloonGameRuntime: vi.fn(() => runtime)
+    });
+
+    page.mount(root);
+    await page.requestCameraAccess();
+    page.selectCameras("front", "side");
+    root.clickAction("reselectCameras");
+    root.clickAction("reselectCameras");
+
+    await vi.waitFor(() => {
+      expect(root.innerHTML).toContain("Fresh Camera");
+    });
+    staleReselect.resolve([
+      createDevice("stale-front", "Stale Front"),
+      createDevice("stale-side", "Stale Side")
+    ]);
+    await Promise.resolve();
+
+    expect(root.innerHTML).toContain("Fresh Camera");
+    expect(root.innerHTML).not.toContain("Stale Front");
+    expect(root.innerHTML).not.toContain("Stale Side");
   });
 });

--- a/tests/unit/app/gameHud.test.ts
+++ b/tests/unit/app/gameHud.test.ts
@@ -13,8 +13,12 @@ describe("renderGameHud", () => {
       result: undefined
     });
 
-    expect(html).toMatch(/<span[^>]*>スコア<\/span>\s*<strong[^>]*>12<\/strong>/);
-    expect(html).toMatch(/<span[^>]*>コンボ<\/span>\s*<strong[^>]*>4<\/strong>/);
+    expect(html).toMatch(
+      /<span[^>]*>スコア<\/span>\s*<strong[^>]*>12<\/strong>/
+    );
+    expect(html).toMatch(
+      /<span[^>]*>コンボ<\/span>\s*<strong[^>]*>4<\/strong>/
+    );
     expect(html).toMatch(/<span[^>]*>倍率<\/span>\s*<strong[^>]*>x2<\/strong>/);
     expect(html).toMatch(/<span[^>]*>残り<\/span>\s*<strong[^>]*>55<\/strong>/);
     expect(html).toContain('data-game-countdown="2"');
@@ -32,8 +36,12 @@ describe("renderGameHud", () => {
     });
 
     expect(html).toContain("結果");
-    expect(html).toMatch(/<span[^>]*>最終スコア<\/span>\s*<strong[^>]*>24<\/strong>/);
-    expect(html).toMatch(/<span[^>]*>最大コンボ<\/span>\s*<strong[^>]*>6<\/strong>/);
+    expect(html).toMatch(
+      /<span[^>]*>最終スコア<\/span>\s*<strong[^>]*>24<\/strong>/
+    );
+    expect(html).toMatch(
+      /<span[^>]*>最大コンボ<\/span>\s*<strong[^>]*>6<\/strong>/
+    );
     expect(html).toContain('data-game-action="retry"');
   });
 
@@ -48,10 +56,34 @@ describe("renderGameHud", () => {
       result: undefined
     });
 
-    expect(html).toContain("入力 &lt;準備&gt; &amp; &quot;確認&quot; &#39;中&#39;");
+    expect(html).toContain(
+      "入力 &lt;準備&gt; &amp; &quot;確認&quot; &#39;中&#39;"
+    );
     expect(html).not.toContain("fusionMode");
     expect(html).not.toContain("fusionRejectReason");
     expect(html).not.toContain("threshold");
     expect(html).not.toContain("unavailable");
+  });
+
+  it("renders a production reselect action for capture-lost status", () => {
+    const html = renderGameHud({
+      score: 0,
+      combo: 0,
+      multiplier: 1,
+      timeRemainingMs: 60_000,
+      countdownLabel: undefined,
+      statusMessage: "カメラが切断されました",
+      statusAction: {
+        action: "reselectCameras",
+        label: "カメラを選び直す"
+      },
+      result: undefined
+    });
+
+    expect(html).toContain("カメラが切断されました");
+    expect(html).toContain("カメラを選び直す");
+    expect(html).toContain('data-game-action="reselectCameras"');
+    expect(html).not.toContain("captureLost");
+    expect(html).not.toContain("laneFailed");
   });
 });

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listeners, liveInspectionMock, workbenchMock } = vi.hoisted(() => {
+const {
+  deviceChangeObserverStop,
+  listeners,
+  liveInspectionMock,
+  observeDeviceChangeMock,
+  workbenchMock
+} = vi.hoisted(() => {
   const listeners = new Map<string, EventListener>();
+  const deviceChangeObserverStop = vi.fn();
+  const observeDeviceChangeMock = vi.fn();
   const liveInspectionMock = {
     getState: vi.fn(() => ({
       frontDetection: undefined,
@@ -58,13 +66,20 @@ const { listeners, liveInspectionMock, workbenchMock } = vi.hoisted(() => {
     })),
     requestPermission: vi.fn(() => Promise.resolve()),
     assignDevices: vi.fn(() => Promise.resolve()),
+    refreshDevicesFromDeviceChange: vi.fn(() => Promise.resolve()),
     swapRoles: vi.fn(() => Promise.resolve()),
     reselect: vi.fn(),
     subscribe: vi.fn(),
     destroy: vi.fn()
   };
 
-  return { listeners, liveInspectionMock, workbenchMock };
+  return {
+    deviceChangeObserverStop,
+    listeners,
+    liveInspectionMock,
+    observeDeviceChangeMock,
+    workbenchMock
+  };
 });
 
 vi.mock("../../src/features/diagnostic-workbench/DiagnosticWorkbench", () => ({
@@ -73,6 +88,10 @@ vi.mock("../../src/features/diagnostic-workbench/DiagnosticWorkbench", () => ({
 
 vi.mock("../../src/features/diagnostic-workbench/renderWorkbench", () => ({
   renderWorkbenchHTML: vi.fn(() => "")
+}));
+
+vi.mock("../../src/features/camera/observeDeviceChange", () => ({
+  observeDeviceChange: observeDeviceChangeMock
 }));
 
 vi.mock(
@@ -96,6 +115,10 @@ describe("diagnostic main input handling", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    observeDeviceChangeMock.mockImplementation((callback: () => void) => {
+      listeners.set("devicechange", callback as EventListener);
+      return { stop: deviceChangeObserverStop };
+    });
     listeners.clear();
     const root = {
       innerHTML: "",
@@ -143,5 +166,21 @@ describe("diagnostic main input handling", () => {
     expect(liveInspectionMock.setFrontAimCalibration).not.toHaveBeenCalled();
     expect(liveInspectionMock.setSideTriggerCalibration).not.toHaveBeenCalled();
     expect(liveInspectionMock.setFusionTuning).not.toHaveBeenCalled();
+  });
+
+  it("refreshes workbench devices when media devices change", async () => {
+    const deviceChangeListener = listeners.get("devicechange");
+
+    if (deviceChangeListener === undefined) {
+      throw new Error("devicechange listener was not registered");
+    }
+
+    deviceChangeListener(new Event("devicechange"));
+
+    await vi.waitFor(() => {
+      expect(
+        workbenchMock.refreshDevicesFromDeviceChange
+      ).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/tests/unit/features/camera/observeDeviceChange.test.ts
+++ b/tests/unit/features/camera/observeDeviceChange.test.ts
@@ -66,4 +66,25 @@ describe("observeDeviceChange", () => {
     observer.stop();
     expect(mediaDevices.ondevicechange).toBe(previous);
   });
+
+  it("does not overwrite a fallback handler installed after observation starts", () => {
+    const previous = vi.fn();
+    const thirdParty = vi.fn();
+    const mediaDevices: FakeMediaDevices = { ondevicechange: previous };
+    stubMediaDevices(mediaDevices);
+    const callback = vi.fn();
+
+    const observer = observeDeviceChange(callback);
+    mediaDevices.ondevicechange = thirdParty;
+
+    observer.stop();
+
+    expect(mediaDevices.ondevicechange).toBe(thirdParty);
+    (mediaDevices.ondevicechange as (event: Event) => void)(
+      new Event("devicechange")
+    );
+    expect(thirdParty).toHaveBeenCalledOnce();
+    expect(previous).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/features/camera/observeDeviceChange.test.ts
+++ b/tests/unit/features/camera/observeDeviceChange.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { observeDeviceChange } from "../../../../src/features/camera/observeDeviceChange";
+
+interface FakeMediaDevices {
+  ondevicechange: ((event: Event) => void) | null;
+  addEventListener?: (type: string, listener: EventListener) => void;
+  removeEventListener?: (type: string, listener: EventListener) => void;
+}
+
+const stubMediaDevices = (mediaDevices: FakeMediaDevices): void => {
+  vi.stubGlobal("navigator", { mediaDevices });
+};
+
+describe("observeDeviceChange", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("attaches and detaches a devicechange listener with addEventListener", () => {
+    const listeners = new Set<EventListener>();
+    const mediaDevices: FakeMediaDevices = {
+      ondevicechange: null,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "devicechange") {
+          listeners.add(listener);
+        }
+      }),
+      removeEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "devicechange") {
+          listeners.delete(listener);
+        }
+      })
+    };
+    stubMediaDevices(mediaDevices);
+    const callback = vi.fn();
+
+    const observer = observeDeviceChange(callback);
+    for (const listener of listeners) {
+      listener(new Event("devicechange"));
+    }
+
+    expect(callback).toHaveBeenCalledOnce();
+
+    observer.stop();
+    observer.stop();
+    for (const listener of listeners) {
+      listener(new Event("devicechange"));
+    }
+
+    expect(mediaDevices.removeEventListener).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("preserves and restores an existing ondevicechange handler fallback", () => {
+    const previous = vi.fn();
+    const mediaDevices: FakeMediaDevices = { ondevicechange: previous };
+    stubMediaDevices(mediaDevices);
+    const callback = vi.fn();
+
+    const observer = observeDeviceChange(callback);
+    mediaDevices.ondevicechange?.(new Event("devicechange"));
+
+    expect(previous).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledOnce();
+
+    observer.stop();
+    expect(mediaDevices.ondevicechange).toBe(previous);
+  });
+});

--- a/tests/unit/features/camera/observeTrackEnded.test.ts
+++ b/tests/unit/features/camera/observeTrackEnded.test.ts
@@ -108,4 +108,12 @@ describe("observeTrackEnded", () => {
     expect(callback.mock.calls[0]?.[0].trackId).toBe("front-a");
     expect(callback.mock.calls[1]?.[0].trackId).toBe("front-b");
   });
+
+  it("fails fast when the stream exposes no track accessors", () => {
+    const stream = {} as MediaStream;
+
+    expect(() => observeTrackEnded(stream, vi.fn())).toThrow(
+      "MediaStream does not support getVideoTracks or getTracks"
+    );
+  });
 });

--- a/tests/unit/features/camera/observeTrackEnded.test.ts
+++ b/tests/unit/features/camera/observeTrackEnded.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  observeTrackEnded,
+  type TrackEndedPayload
+} from "../../../../src/features/camera/observeTrackEnded";
+
+class FakeTrack {
+  readonly kind: string;
+  readonly id: string;
+  readonly label: string;
+  readyState: MediaStreamTrackState = "live";
+  private readonly listeners = new Set<EventListener>();
+
+  constructor({
+    id,
+    kind = "video",
+    label = ""
+  }: {
+    readonly id: string;
+    readonly kind?: string;
+    readonly label?: string;
+  }) {
+    this.id = id;
+    this.kind = kind;
+    this.label = label;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.listeners.delete(listener);
+    }
+  }
+
+  fireEnded(): void {
+    this.readyState = "ended";
+    for (const listener of this.listeners) {
+      listener(new Event("ended"));
+    }
+  }
+
+  listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+const createStream = (tracks: readonly FakeTrack[]): MediaStream =>
+  ({
+    getVideoTracks: vi.fn(() =>
+      tracks.filter((track) => track.kind === "video")
+    ),
+    getTracks: vi.fn(() => [...tracks])
+  }) as unknown as MediaStream;
+
+describe("observeTrackEnded", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls the callback with ended video track details", () => {
+    const track = new FakeTrack({ id: "front-track", label: "Front <Cam>" });
+    const callback = vi.fn<(payload: TrackEndedPayload) => void>();
+
+    observeTrackEnded(createStream([track]), callback);
+    track.fireEnded();
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback.mock.calls[0]?.[0].trackId).toBe("front-track");
+    expect(callback.mock.calls[0]?.[0].readyState).toBe("ended");
+    expect(callback.mock.calls[0]?.[0].label).toBe("Front <Cam>");
+  });
+
+  it("detaches listeners when stopped and ignores non-video tracks", () => {
+    const videoTrack = new FakeTrack({ id: "video-track" });
+    const audioTrack = new FakeTrack({ id: "audio-track", kind: "audio" });
+    const callback = vi.fn<(payload: TrackEndedPayload) => void>();
+    const observer = observeTrackEnded(
+      createStream([videoTrack, audioTrack]),
+      callback
+    );
+
+    expect(videoTrack.listenerCount()).toBe(1);
+    expect(audioTrack.listenerCount()).toBe(0);
+
+    observer.stop();
+    observer.stop();
+    videoTrack.fireEnded();
+
+    expect(videoTrack.listenerCount()).toBe(0);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("observes every video track independently", () => {
+    const firstTrack = new FakeTrack({ id: "front-a" });
+    const secondTrack = new FakeTrack({ id: "front-b" });
+    const callback = vi.fn<(payload: TrackEndedPayload) => void>();
+
+    observeTrackEnded(createStream([firstTrack, secondTrack]), callback);
+    firstTrack.fireEnded();
+    secondTrack.fireEnded();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.calls[0]?.[0].trackId).toBe("front-a");
+    expect(callback.mock.calls[1]?.[0].trackId).toBe("front-b");
+  });
+});

--- a/tests/unit/features/camera/observeTrackEnded.test.ts
+++ b/tests/unit/features/camera/observeTrackEnded.test.ts
@@ -13,6 +13,13 @@ const createStream = (tracks: readonly FakeTrack[]): MediaStream =>
     getTracks: vi.fn(() => [...tracks])
   }) as unknown as MediaStream;
 
+const createStreamWithoutGetVideoTracks = (
+  tracks: readonly FakeTrack[]
+): MediaStream =>
+  ({
+    getTracks: vi.fn(() => [...tracks])
+  }) as unknown as MediaStream;
+
 describe("observeTrackEnded", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -63,6 +70,23 @@ describe("observeTrackEnded", () => {
     expect(callback).toHaveBeenCalledTimes(2);
     expect(callback.mock.calls[0]?.[0].trackId).toBe("front-a");
     expect(callback.mock.calls[1]?.[0].trackId).toBe("front-b");
+  });
+
+  it("ignores non-video tracks via getTracks fallback", () => {
+    const videoTrack = new FakeTrack("video-track");
+    const audioTrack = new FakeTrack("audio-track", "audio-track", "audio");
+    const callback = vi.fn<(payload: TrackEndedPayload) => void>();
+
+    observeTrackEnded(
+      createStreamWithoutGetVideoTracks([videoTrack, audioTrack]),
+      callback
+    );
+    audioTrack.fireEnded();
+    videoTrack.fireEnded();
+
+    expect(audioTrack.listenerCount()).toBe(0);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback.mock.calls[0]?.[0].trackId).toBe("video-track");
   });
 
   it("fails fast when the stream exposes no track accessors", () => {

--- a/tests/unit/features/camera/observeTrackEnded.test.ts
+++ b/tests/unit/features/camera/observeTrackEnded.test.ts
@@ -3,51 +3,7 @@ import {
   observeTrackEnded,
   type TrackEndedPayload
 } from "../../../../src/features/camera/observeTrackEnded";
-
-class FakeTrack {
-  readonly kind: string;
-  readonly id: string;
-  readonly label: string;
-  readyState: MediaStreamTrackState = "live";
-  private readonly listeners = new Set<EventListener>();
-
-  constructor({
-    id,
-    kind = "video",
-    label = ""
-  }: {
-    readonly id: string;
-    readonly kind?: string;
-    readonly label?: string;
-  }) {
-    this.id = id;
-    this.kind = kind;
-    this.label = label;
-  }
-
-  addEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.listeners.add(listener);
-    }
-  }
-
-  removeEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.listeners.delete(listener);
-    }
-  }
-
-  fireEnded(): void {
-    this.readyState = "ended";
-    for (const listener of this.listeners) {
-      listener(new Event("ended"));
-    }
-  }
-
-  listenerCount(): number {
-    return this.listeners.size;
-  }
-}
+import { FakeTrack } from "../../../helpers/fakeTrack";
 
 const createStream = (tracks: readonly FakeTrack[]): MediaStream =>
   ({
@@ -63,7 +19,7 @@ describe("observeTrackEnded", () => {
   });
 
   it("calls the callback with ended video track details", () => {
-    const track = new FakeTrack({ id: "front-track", label: "Front <Cam>" });
+    const track = new FakeTrack("front-track", "Front <Cam>");
     const callback = vi.fn<(payload: TrackEndedPayload) => void>();
 
     observeTrackEnded(createStream([track]), callback);
@@ -76,8 +32,8 @@ describe("observeTrackEnded", () => {
   });
 
   it("detaches listeners when stopped and ignores non-video tracks", () => {
-    const videoTrack = new FakeTrack({ id: "video-track" });
-    const audioTrack = new FakeTrack({ id: "audio-track", kind: "audio" });
+    const videoTrack = new FakeTrack("video-track");
+    const audioTrack = new FakeTrack("audio-track", "audio-track", "audio");
     const callback = vi.fn<(payload: TrackEndedPayload) => void>();
     const observer = observeTrackEnded(
       createStream([videoTrack, audioTrack]),
@@ -96,8 +52,8 @@ describe("observeTrackEnded", () => {
   });
 
   it("observes every video track independently", () => {
-    const firstTrack = new FakeTrack({ id: "front-a" });
-    const secondTrack = new FakeTrack({ id: "front-b" });
+    const firstTrack = new FakeTrack("front-a");
+    const secondTrack = new FakeTrack("front-b");
     const callback = vi.fn<(payload: TrackEndedPayload) => void>();
 
     observeTrackEnded(createStream([firstTrack, secondTrack]), callback);

--- a/tests/unit/features/camera/reconnectPolicy.test.ts
+++ b/tests/unit/features/camera/reconnectPolicy.test.ts
@@ -27,10 +27,12 @@ describe("createReconnectBudget", () => {
     budget.recordFailure("frontAim", 1_000);
     budget.recordFailure("frontAim", 1_100);
     budget.recordFailure("frontAim", 1_200);
+    budget.recordFailure("sideTrigger", 1_000);
+    budget.recordFailure("sideTrigger", 1_100);
     budget.recordFailure("sideTrigger", 1_200);
     budget.recordSuccess("frontAim");
 
     expect(budget.canAttempt("frontAim", 1_300)).toBe(true);
-    expect(budget.canAttempt("sideTrigger", 1_300)).toBe(true);
+    expect(budget.canAttempt("sideTrigger", 1_300)).toBe(false);
   });
 });

--- a/tests/unit/features/camera/reconnectPolicy.test.ts
+++ b/tests/unit/features/camera/reconnectPolicy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAMERA_RECONNECT_COOLDOWN_MS,
+  MAX_CAMERA_RECONNECT_ATTEMPTS,
+  createReconnectBudget
+} from "../../../../src/features/camera/reconnectPolicy";
+
+describe("createReconnectBudget", () => {
+  it("blocks attempts after repeated failures within the cooldown window", () => {
+    const budget = createReconnectBudget();
+
+    expect(CAMERA_RECONNECT_COOLDOWN_MS).toBe(1_000);
+    expect(MAX_CAMERA_RECONNECT_ATTEMPTS).toBe(3);
+
+    expect(budget.canAttempt("frontAim", 1_000)).toBe(true);
+    budget.recordFailure("frontAim", 1_000);
+    budget.recordFailure("frontAim", 1_100);
+    budget.recordFailure("frontAim", 1_200);
+
+    expect(budget.canAttempt("frontAim", 1_300)).toBe(false);
+    expect(budget.canAttempt("frontAim", 2_201)).toBe(true);
+  });
+
+  it("success clears the failure budget for that key only", () => {
+    const budget = createReconnectBudget();
+
+    budget.recordFailure("frontAim", 1_000);
+    budget.recordFailure("frontAim", 1_100);
+    budget.recordFailure("frontAim", 1_200);
+    budget.recordFailure("sideTrigger", 1_200);
+    budget.recordSuccess("frontAim");
+
+    expect(budget.canAttempt("frontAim", 1_300)).toBe(true);
+    expect(budget.canAttempt("sideTrigger", 1_300)).toBe(true);
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -131,6 +131,25 @@ describe("createDiagnosticWorkbench", () => {
     expect(workbench.getState().devices).toHaveLength(1);
   });
 
+  it("refreshes single-camera selection to device selection on devicechange", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices)
+      .mockResolvedValueOnce([createDevice("front-id", "Front Camera")])
+      .mockResolvedValueOnce([
+        createDevice("front-id", "Front Camera"),
+        createDevice("side-id", "Side Camera")
+      ]);
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+    await workbench.refreshDevicesFromDeviceChange();
+
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(
+      workbench.getState().devices.map((device) => device.deviceId)
+    ).toEqual(["front-id", "side-id"]);
+  });
+
   it("renders deviceSelection after permission and two-camera enumeration", async () => {
     grantPermission();
     enumerateTwoDevices();
@@ -240,7 +259,9 @@ describe("createDiagnosticWorkbench", () => {
     const workbench = createDiagnosticWorkbench();
     await workbench.requestPermission();
 
-    await expect(workbench.assignDevices("front-id", "front-id")).resolves.toBeUndefined();
+    await expect(
+      workbench.assignDevices("front-id", "front-id")
+    ).resolves.toBeUndefined();
     expect(workbench.getState().screen).toBe("deviceSelection");
     expect(workbench.getState().error?.kind).toBe("distinctDevicesRequired");
   });
@@ -287,6 +308,63 @@ describe("createDiagnosticWorkbench", () => {
     expect(workbench.getState().frontStream).toBe(frontStream);
     expect(workbench.getState().sideStream).toBe(sideStream);
     expect(workbench.getState().error?.kind).toBe("cameraConstraintFailed");
+  });
+
+  it("refreshes devices while previewing without opening replacement streams", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    vi.mocked(enumerateVideoDevices).mockResolvedValueOnce([
+      createDevice("front-id", "Front Camera"),
+      createDevice("side-id", "Side Camera"),
+      createDevice("replugged-id", "Replugged Camera")
+    ]);
+
+    await workbench.refreshDevicesFromDeviceChange();
+
+    expect(workbench.getState().screen).toBe("previewing");
+    expect(
+      workbench.getState().devices.map((device) => device.deviceId)
+    ).toEqual(["front-id", "side-id", "replugged-id"]);
+    expect(workbench.getState().frontStream).toBe(frontStream);
+    expect(workbench.getState().sideStream).toBe(sideStream);
+    expect(createDevicePinnedStream).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores stale devicechange enumeration results", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+
+    const firstRefresh = createDeferred<MediaDeviceInfo[]>();
+    vi.mocked(enumerateVideoDevices)
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockResolvedValueOnce([
+        createDevice("front-id", "Front Camera"),
+        createDevice("side-id", "Side Camera"),
+        createDevice("fresh-id", "Fresh Camera")
+      ]);
+
+    const stale = workbench.refreshDevicesFromDeviceChange();
+    const fresh = workbench.refreshDevicesFromDeviceChange();
+    await fresh;
+    firstRefresh.resolve([
+      createDevice("stale-front", "Stale Front"),
+      createDevice("stale-side", "Stale Side")
+    ]);
+    await stale;
+
+    expect(
+      workbench.getState().devices.map((device) => device.deviceId)
+    ).toEqual(["front-id", "side-id", "fresh-id"]);
   });
 
   it("stops existing preview streams when requesting permission again", async () => {

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -411,6 +411,39 @@ describe("createDiagnosticWorkbench", () => {
     ).toEqual(["front-id", "side-id", "fresh-id"]);
   });
 
+  it("ignores stale devicechange results after assigning devices", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+
+    const staleRefresh = createDeferred<MediaDeviceInfo[]>();
+    vi.mocked(enumerateVideoDevices).mockReturnValueOnce(staleRefresh.promise);
+
+    const refresh = workbench.refreshDevicesFromDeviceChange();
+    await workbench.assignDevices("front-id", "side-id");
+
+    staleRefresh.resolve([
+      createDevice("stale-front", "Stale Front"),
+      createDevice("stale-side", "Stale Side")
+    ]);
+    await refresh;
+
+    expect(workbench.getState()).toMatchObject({
+      screen: "previewing",
+      frontStream,
+      sideStream
+    });
+    expect(
+      workbench.getState().devices.map((device) => device.deviceId)
+    ).toEqual(["front-id", "side-id"]);
+  });
+
   it("stops existing preview streams when requesting permission again", async () => {
     grantPermission();
     enumerateTwoDevices();

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -411,6 +411,36 @@ describe("createDiagnosticWorkbench", () => {
     ).toEqual(["front-id", "side-id", "fresh-id"]);
   });
 
+  it("keeps devicechange results newer than in-flight permission enumeration", async () => {
+    const permissionEnumeration = createDeferred<MediaDeviceInfo[]>();
+    grantPermission();
+    vi.mocked(enumerateVideoDevices)
+      .mockReturnValueOnce(permissionEnumeration.promise)
+      .mockResolvedValueOnce([
+        createDevice("new-front-id", "New Front Camera"),
+        createDevice("new-side-id", "New Side Camera"),
+        createDevice("new-extra-id", "New Extra Camera")
+      ]);
+    const workbench = createDiagnosticWorkbench();
+
+    const request = workbench.requestPermission();
+    await vi.waitFor(() => {
+      expect(enumerateVideoDevices).toHaveBeenCalledOnce();
+    });
+    await workbench.refreshDevicesFromDeviceChange();
+    permissionEnumeration.resolve([
+      createDevice("old-front-id", "Old Front Camera"),
+      createDevice("old-side-id", "Old Side Camera")
+    ]);
+    await request;
+
+    expect(enumerateVideoDevices).toHaveBeenCalledTimes(2);
+    expect(workbench.getState().screen).toBe("deviceSelection");
+    expect(
+      workbench.getState().devices.map((device) => device.deviceId)
+    ).toEqual(["new-front-id", "new-side-id", "new-extra-id"]);
+  });
+
   it("ignores stale devicechange results after assigning devices", async () => {
     grantPermission();
     enumerateTwoDevices();
@@ -502,6 +532,46 @@ describe("createDiagnosticWorkbench", () => {
     expect(sideStream.stopMock).toHaveBeenCalledOnce();
     expect(workbench.getState().screen).toBe("deviceSelection");
     expect(workbench.getState().frontStream).toBeUndefined();
+  });
+
+  it("keeps a reconnect cooldown action newer than an in-flight preview open", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("front-id", "Front Camera"),
+      createDevice("side-id", "Side Camera"),
+      createDevice("cooldown-front-id", "Cooldown Front Camera"),
+      createDevice("cooldown-side-id", "Cooldown Side Camera")
+    ]);
+    vi.mocked(createDevicePinnedStream)
+      .mockRejectedValueOnce(createCameraError("NotReadableError"))
+      .mockRejectedValueOnce(createCameraError("NotReadableError"))
+      .mockRejectedValueOnce(createCameraError("NotReadableError"));
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("cooldown-front-id", "cooldown-side-id");
+    await workbench.assignDevices("cooldown-front-id", "cooldown-side-id");
+    await workbench.assignDevices("cooldown-front-id", "cooldown-side-id");
+    const frontDeferred = createDeferred<DevicePinnedStream>();
+    const sideDeferred = createDeferred<DevicePinnedStream>();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockReturnValueOnce(frontDeferred.promise)
+      .mockReturnValueOnce(sideDeferred.promise);
+
+    const assignment = workbench.assignDevices("front-id", "side-id");
+    frontDeferred.resolve(frontStream);
+    await Promise.resolve();
+    await workbench.assignDevices("cooldown-front-id", "cooldown-side-id");
+    sideDeferred.resolve(sideStream);
+    await assignment;
+
+    expect(frontStream.stopMock).toHaveBeenCalledOnce();
+    expect(sideStream.stopMock).toHaveBeenCalledOnce();
+    expect(workbench.getState().screen).toBe("cameraOpenFailed");
+    expect(workbench.getState().error?.kind).toBe("reconnectCooldown");
+    expect(workbench.getState().frontStream).toBeUndefined();
+    expect(workbench.getState().sideStream).toBeUndefined();
   });
 
   it("stops streams returned after destroy invalidates an in-flight open", async () => {

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -382,6 +382,31 @@ describe("createDiagnosticWorkbench", () => {
     expect(createDevicePinnedStream).toHaveBeenCalledTimes(2);
   });
 
+  it("preserves preview assignment labels when a selected camera disappears", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("front-id", "Logitech HD"),
+      createDevice("side-id", "Side Camera")
+    ]);
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    vi.mocked(enumerateVideoDevices).mockResolvedValueOnce([
+      createDevice("side-id", "Side Camera")
+    ]);
+
+    await workbench.refreshDevicesFromDeviceChange();
+
+    expect(workbench.getState().screen).toBe("previewing");
+    expect(workbench.getState().frontAssignment?.label).toBe("Logitech HD");
+    expect(workbench.getState().sideAssignment?.label).toBe("Side Camera");
+  });
+
   it("ignores stale devicechange enumeration results", async () => {
     grantPermission();
     enumerateTwoDevices();
@@ -532,6 +557,52 @@ describe("createDiagnosticWorkbench", () => {
     expect(sideStream.stopMock).toHaveBeenCalledOnce();
     expect(workbench.getState().screen).toBe("deviceSelection");
     expect(workbench.getState().frontStream).toBeUndefined();
+  });
+
+  it("routes reselect to cameraNotFound when no devices remain during preview", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    vi.mocked(enumerateVideoDevices).mockResolvedValueOnce([]);
+
+    await workbench.refreshDevicesFromDeviceChange();
+    workbench.reselect();
+
+    expect(workbench.getState().screen).toBe("cameraNotFound");
+    expect(workbench.getState().error?.kind).toBe("cameraNotFound");
+    expect(workbench.getState().frontStream).toBeUndefined();
+    expect(workbench.getState().sideStream).toBeUndefined();
+  });
+
+  it("routes reselect to singleCamera when one device remains during preview", async () => {
+    grantPermission();
+    enumerateTwoDevices();
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+    vi.mocked(enumerateVideoDevices).mockResolvedValueOnce([
+      createDevice("front-id", "Front Camera")
+    ]);
+
+    await workbench.refreshDevicesFromDeviceChange();
+    workbench.reselect();
+
+    expect(workbench.getState().screen).toBe("singleCamera");
+    expect(workbench.getState().error).toBeUndefined();
+    expect(workbench.getState().frontStream).toBeUndefined();
+    expect(workbench.getState().sideStream).toBeUndefined();
   });
 
   it("keeps a reconnect cooldown action newer than an in-flight preview open", async () => {

--- a/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/DiagnosticWorkbench.test.ts
@@ -88,6 +88,27 @@ describe("createDiagnosticWorkbench", () => {
     expect(enumerateVideoDevices).not.toHaveBeenCalled();
   });
 
+  it("ignores devicechange refreshes after camera permission was denied", async () => {
+    vi.mocked(requestCameraPermission).mockResolvedValue({
+      status: "denied",
+      error: createCameraError("NotAllowedError")
+    });
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("front-id", "Front Camera"),
+      createDevice("side-id", "Side Camera")
+    ]);
+
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+    vi.mocked(enumerateVideoDevices).mockClear();
+    await workbench.refreshDevicesFromDeviceChange();
+
+    expect(enumerateVideoDevices).not.toHaveBeenCalled();
+    expect(workbench.getState().screen).toBe("permissionDenied");
+    expect(workbench.getState().error?.kind).toBe("permissionDenied");
+  });
+
   it("renders permissionFailed state for non-denied permission failures", async () => {
     vi.mocked(requestCameraPermission).mockResolvedValue({
       status: "failed",
@@ -264,6 +285,29 @@ describe("createDiagnosticWorkbench", () => {
     ).resolves.toBeUndefined();
     expect(workbench.getState().screen).toBe("deviceSelection");
     expect(workbench.getState().error?.kind).toBe("distinctDevicesRequired");
+  });
+
+  it("keeps reconnect failure budgets independent for device ids containing colons", async () => {
+    grantPermission();
+    vi.mocked(enumerateVideoDevices).mockResolvedValue([
+      createDevice("a:b", "Front With Colon"),
+      createDevice("c", "Side C"),
+      createDevice("a", "Front A"),
+      createDevice("b:c", "Side With Colon")
+    ]);
+    vi.mocked(createDevicePinnedStream).mockRejectedValue(
+      createCameraError("NotReadableError")
+    );
+    const workbench = createDiagnosticWorkbench();
+
+    await workbench.requestPermission();
+    await workbench.assignDevices("a:b", "c");
+    await workbench.assignDevices("a:b", "c");
+    await workbench.assignDevices("a:b", "c");
+    await workbench.assignDevices("a", "b:c");
+
+    expect(createDevicePinnedStream).toHaveBeenCalledTimes(4);
+    expect(workbench.getState().error?.kind).toBe("cameraOpenFailed");
   });
 
   it("stops a successful first stream when the paired side stream fails", async () => {

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -1320,13 +1320,14 @@ describe("createLiveLandmarkInspection", () => {
   });
 
   it("preserves calibration across same-device reselection after capture loss", () => {
+    const frontTrack = new FakeTrack("front-track");
     const liveInspection = createLiveLandmarkInspection();
     const previewState = {
       screen: "previewing" as const,
       devices: [],
       frontAssignment: undefined,
       sideAssignment: undefined,
-      frontStream: createPinnedStream("front-id"),
+      frontStream: createPinnedStream("front-id", [frontTrack]),
       sideStream: createPinnedStream("side-id"),
       error: undefined
     };
@@ -1339,15 +1340,22 @@ describe("createLiveLandmarkInspection", () => {
       sideStream: undefined,
       error: undefined
     };
+    const sameDevicePreviewState = {
+      ...previewState,
+      frontStream: createPinnedStream("front-id")
+    };
 
+    installPreviewVideos();
+    liveInspection.sync(previewState);
     liveInspection.setFrontAimCalibration("centerX", 0.6);
     liveInspection.setSideTriggerCalibration("openPoseDistance", 1);
+    frontTrack.fireEnded();
 
-    installPreviewVideos();
-    liveInspection.sync(previewState);
+    expect(liveInspection.getState().frontLaneHealth).toBe("captureLost");
+
     liveInspection.sync(deviceSelectionState);
     installPreviewVideos();
-    liveInspection.sync(previewState);
+    liveInspection.sync(sameDevicePreviewState);
 
     expect(liveInspection.getState().frontAimCalibration.center.x).toBe(0.6);
     expect(
@@ -1357,13 +1365,14 @@ describe("createLiveLandmarkInspection", () => {
   });
 
   it("resets calibration when a different device is selected after capture loss", () => {
+    const frontTrack = new FakeTrack("front-track");
     const liveInspection = createLiveLandmarkInspection();
     const initialPreviewState = {
       screen: "previewing" as const,
       devices: [],
       frontAssignment: undefined,
       sideAssignment: undefined,
-      frontStream: createPinnedStream("front-id"),
+      frontStream: createPinnedStream("front-id", [frontTrack]),
       sideStream: createPinnedStream("side-id"),
       error: undefined
     };
@@ -1381,11 +1390,14 @@ describe("createLiveLandmarkInspection", () => {
       frontStream: createPinnedStream("front-replacement-id")
     };
 
-    liveInspection.setFrontAimCalibration("centerX", 0.6);
-    liveInspection.setSideTriggerCalibration("openPoseDistance", 1);
-
     installPreviewVideos();
     liveInspection.sync(initialPreviewState);
+    liveInspection.setFrontAimCalibration("centerX", 0.6);
+    liveInspection.setSideTriggerCalibration("openPoseDistance", 1);
+    frontTrack.fireEnded();
+
+    expect(liveInspection.getState().frontLaneHealth).toBe("captureLost");
+
     liveInspection.sync(deviceSelectionState);
     installPreviewVideos();
     liveInspection.sync(differentPreviewState);

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -27,6 +27,7 @@ import {
   openWorldLandmarks,
   pulledWorldLandmarks
 } from "../side-trigger/testFactory";
+import { FakeTrack } from "../../../helpers/fakeTrack";
 
 const { createMediaPipeHandTrackerMock } = vi.hoisted(() => ({
   createMediaPipeHandTrackerMock: vi.fn()
@@ -92,42 +93,6 @@ type VideoFrameCallbackLike = (
 interface FakeTracker {
   detect: ReturnType<typeof vi.fn>;
   cleanup: ReturnType<typeof vi.fn>;
-}
-
-class FakeTrack {
-  readonly id: string;
-  readonly kind = "video";
-  readonly label: string;
-  readyState: MediaStreamTrackState = "live";
-  private readonly endedListeners = new Set<EventListener>();
-
-  constructor(id: string, label = id) {
-    this.id = id;
-    this.label = label;
-  }
-
-  addEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.endedListeners.add(listener);
-    }
-  }
-
-  removeEventListener(type: string, listener: EventListener): void {
-    if (type === "ended") {
-      this.endedListeners.delete(listener);
-    }
-  }
-
-  fireEnded(): void {
-    this.readyState = "ended";
-    for (const listener of this.endedListeners) {
-      listener(new Event("ended"));
-    }
-  }
-
-  listenerCount(): number {
-    return this.endedListeners.size;
-  }
 }
 
 const elements = new Map<string, unknown>();

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -94,6 +94,42 @@ interface FakeTracker {
   cleanup: ReturnType<typeof vi.fn>;
 }
 
+class FakeTrack {
+  readonly id: string;
+  readonly kind = "video";
+  readonly label: string;
+  readyState: MediaStreamTrackState = "live";
+  private readonly endedListeners = new Set<EventListener>();
+
+  constructor(id: string, label = id) {
+    this.id = id;
+    this.label = label;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (type === "ended") {
+      this.endedListeners.delete(listener);
+    }
+  }
+
+  fireEnded(): void {
+    this.readyState = "ended";
+    for (const listener of this.endedListeners) {
+      listener(new Event("ended"));
+    }
+  }
+
+  listenerCount(): number {
+    return this.endedListeners.size;
+  }
+}
+
 const elements = new Map<string, unknown>();
 
 const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
@@ -105,8 +141,15 @@ const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
     toJSON: () => ({})
   }) as MediaDeviceInfo;
 
-const createPinnedStream = (deviceId: string): DevicePinnedStream => ({
-  stream: { id: `${deviceId}-stream` } as MediaStream,
+const createPinnedStream = (
+  deviceId: string,
+  tracks: readonly FakeTrack[] = []
+): DevicePinnedStream => ({
+  stream: {
+    id: `${deviceId}-stream`,
+    getVideoTracks: vi.fn(() => [...tracks]),
+    getTracks: vi.fn(() => [...tracks])
+  } as unknown as MediaStream,
   deviceId,
   stop: vi.fn()
 });
@@ -483,6 +526,86 @@ describe("createLiveLandmarkInspection", () => {
       expect(frontTracker.cleanup).toHaveBeenCalledOnce();
       expect(sideTracker.cleanup).toHaveBeenCalledOnce();
     });
+  });
+
+  it("sets front lane to captureLost and clears stale aim snapshots when its track ends", async () => {
+    const frontTrack = new FakeTrack("front-track");
+    const frontTracker = createFakeTracker();
+    frontTracker.detect.mockResolvedValueOnce(createHandDetection());
+    createMediaPipeHandTrackerMock.mockResolvedValueOnce(frontTracker);
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id", [frontTrack]),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    });
+    videos.frontVideo.fireFrame({ captureTime: 100, presentedFrames: 1 });
+
+    await vi.waitFor(() => {
+      expect(liveInspection.getState().frontAimFrame).toBeDefined();
+    });
+    frontTrack.fireEnded();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.cleanup).toHaveBeenCalledOnce();
+    });
+    expect(liveInspection.getState().frontLaneHealth).toBe("captureLost");
+    expect(liveInspection.getState().frontDetection).toBeUndefined();
+    expect(liveInspection.getState().frontAimFrame).toBeUndefined();
+    expect(liveInspection.getState().frontAimTelemetry).toBeUndefined();
+    expect(liveInspection.getState().fusionFrame?.fusionRejectReason).toBe(
+      "laneFailed"
+    );
+    expect(liveInspection.getState().fusionFrame?.frontSource.laneHealth).toBe(
+      "captureLost"
+    );
+    expect(videos.frontVideo.cancelVideoFrameCallback).toHaveBeenCalledOnce();
+    expect(frontTrack.listenerCount()).toBe(0);
+  });
+
+  it("sets side lane to captureLost and clears stale trigger snapshots when its track ends", async () => {
+    const sideTrack = new FakeTrack("side-track");
+    const sideTracker = setupSideTrackerSequence();
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id", [sideTrack]),
+      error: undefined
+    });
+    videos.sideVideo.fireFrame({ captureTime: 100, presentedFrames: 1 });
+
+    await vi.waitFor(() => {
+      expect(liveInspection.getState().sideTriggerFrame).toBeDefined();
+    });
+    sideTrack.fireEnded();
+
+    await vi.waitFor(() => {
+      expect(sideTracker.cleanup).toHaveBeenCalledOnce();
+    });
+    expect(liveInspection.getState().sideLaneHealth).toBe("captureLost");
+    expect(liveInspection.getState().sideDetection).toBeUndefined();
+    expect(liveInspection.getState().sideTriggerFrame).toBeUndefined();
+    expect(liveInspection.getState().sideTriggerTelemetry).toBeUndefined();
+    expect(liveInspection.getState().fusionFrame?.fusionRejectReason).toBe(
+      "laneFailed"
+    );
+    expect(liveInspection.getState().fusionFrame?.sideSource.laneHealth).toBe(
+      "captureLost"
+    );
+    expect(liveInspection.getState().fusionFrame?.shotFired).toBe(false);
+    expect(sideTrack.listenerCount()).toBe(0);
   });
 
   it("passes lane-specific filter configs to diagnostic trackers", async () => {
@@ -1161,7 +1284,7 @@ describe("createLiveLandmarkInspection", () => {
     });
   });
 
-  it("keeps calibration during non-preview syncs until a preview session is left", () => {
+  it("preserves calibration across same-device reselection after capture loss", () => {
     const liveInspection = createLiveLandmarkInspection();
     const previewState = {
       screen: "previewing" as const,
@@ -1184,17 +1307,53 @@ describe("createLiveLandmarkInspection", () => {
 
     liveInspection.setFrontAimCalibration("centerX", 0.6);
     liveInspection.setSideTriggerCalibration("openPoseDistance", 1);
+
+    installPreviewVideos();
+    liveInspection.sync(previewState);
     liveInspection.sync(deviceSelectionState);
+    installPreviewVideos();
+    liveInspection.sync(previewState);
 
     expect(liveInspection.getState().frontAimCalibration.center.x).toBe(0.6);
     expect(
       liveInspection.getState().sideTriggerCalibration.openPose
         .normalizedThumbDistance
     ).toBe(1);
+  });
+
+  it("resets calibration when a different device is selected after capture loss", () => {
+    const liveInspection = createLiveLandmarkInspection();
+    const initialPreviewState = {
+      screen: "previewing" as const,
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    };
+    const deviceSelectionState = {
+      screen: "deviceSelection" as const,
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: undefined,
+      sideStream: undefined,
+      error: undefined
+    };
+    const differentPreviewState = {
+      ...initialPreviewState,
+      frontStream: createPinnedStream("front-replacement-id")
+    };
+
+    liveInspection.setFrontAimCalibration("centerX", 0.6);
+    liveInspection.setSideTriggerCalibration("openPoseDistance", 1);
 
     installPreviewVideos();
-    liveInspection.sync(previewState);
+    liveInspection.sync(initialPreviewState);
     liveInspection.sync(deviceSelectionState);
+    installPreviewVideos();
+    liveInspection.sync(differentPreviewState);
 
     expect(liveInspection.getState().frontAimCalibration).toEqual(
       defaultFrontAimCalibration

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -108,10 +108,11 @@ const createDevice = (deviceId: string, label: string): MediaDeviceInfo =>
 
 const createPinnedStream = (
   deviceId: string,
-  tracks: readonly FakeTrack[] = []
+  tracks: readonly FakeTrack[] = [],
+  streamId = `${deviceId}-stream`
 ): DevicePinnedStream => ({
   stream: {
-    id: `${deviceId}-stream`,
+    id: streamId,
     getVideoTracks: vi.fn(() => [...tracks]),
     getTracks: vi.fn(() => [...tracks])
   } as unknown as MediaStream,
@@ -496,6 +497,47 @@ describe("createLiveLandmarkInspection", () => {
     expect(createMediaPipeHandTrackerMock).toHaveBeenCalledTimes(2);
     expect(frontTracker.cleanup).not.toHaveBeenCalled();
     expect(sideTracker.cleanup).not.toHaveBeenCalled();
+  });
+
+  it("does not double-schedule a rebound video after an in-flight frame finishes", async () => {
+    const detection = createDeferred<HandDetection | undefined>();
+    const frontTracker = createFakeTracker();
+    frontTracker.detect.mockReturnValueOnce(detection.promise);
+    createMediaPipeHandTrackerMock.mockResolvedValueOnce(frontTracker);
+    const liveInspection = createLiveLandmarkInspection();
+    const previewState = {
+      screen: "previewing" as const,
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    };
+    const initialVideos = installPreviewVideos();
+
+    liveInspection.sync(previewState);
+    initialVideos.frontVideo.fireFrame();
+    await vi.waitFor(() => {
+      expect(frontTracker.detect).toHaveBeenCalledOnce();
+    });
+
+    const reboundVideos = installPreviewVideos();
+    liveInspection.sync(previewState);
+
+    expect(
+      reboundVideos.frontVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
+
+    detection.resolve(undefined);
+    await vi.waitFor(() => {
+      expect(liveInspection.getState().frontLaneHealth).toBe("tracking");
+    });
+    await Promise.resolve();
+
+    expect(
+      reboundVideos.frontVideo.requestVideoFrameCallback
+    ).toHaveBeenCalledOnce();
   });
 
   it("preserves calibration when the same preview session re-renders fresh video elements", () => {
@@ -1342,7 +1384,11 @@ describe("createLiveLandmarkInspection", () => {
     };
     const sameDevicePreviewState = {
       ...previewState,
-      frontStream: createPinnedStream("front-id")
+      frontStream: createPinnedStream(
+        "front-id",
+        [],
+        "front-id-reconnected-stream"
+      )
     };
 
     installPreviewVideos();

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -463,6 +463,76 @@ describe("createLiveLandmarkInspection", () => {
     ).toHaveBeenCalledOnce();
   });
 
+  it("retains MediaPipe trackers when passive devicechange keeps the same preview streams", async () => {
+    const frontTracker = createFakeTracker();
+    const sideTracker = createFakeTracker();
+    createMediaPipeHandTrackerMock
+      .mockResolvedValueOnce(frontTracker)
+      .mockResolvedValueOnce(sideTracker)
+      .mockResolvedValue(createFakeTracker());
+    const frontStream = createPinnedStream("front-id");
+    const sideStream = createPinnedStream("side-id");
+    vi.mocked(createDevicePinnedStream)
+      .mockResolvedValueOnce(frontStream)
+      .mockResolvedValueOnce(sideStream);
+    const workbench = createDiagnosticWorkbench();
+    const liveInspection = createLiveLandmarkInspection();
+    let currentVideos: ReturnType<typeof installPreviewVideos> | undefined;
+    const render = (): void => {
+      const state = workbench.getState();
+      renderWorkbenchHTML(state, liveInspection.getState());
+
+      if (state.screen === "previewing") {
+        currentVideos = installPreviewVideos();
+        attachVideoStreams(workbench, currentVideos);
+      }
+
+      liveInspection.sync(state);
+      liveInspection.updateDom();
+    };
+
+    workbench.subscribe(render);
+    await workbench.requestPermission();
+    await workbench.assignDevices("front-id", "side-id");
+
+    const initialVideos = currentVideos;
+    expect(initialVideos).toBeDefined();
+    if (initialVideos === undefined) {
+      throw new Error("preview videos should be installed");
+    }
+    initialVideos.frontVideo.fireFrame();
+    initialVideos.sideVideo.fireFrame();
+
+    await vi.waitFor(() => {
+      expect(createMediaPipeHandTrackerMock).toHaveBeenCalledTimes(2);
+    });
+    vi.mocked(enumerateVideoDevices).mockResolvedValueOnce([
+      createDevice("front-id", "Front Camera"),
+      createDevice("side-id", "Side Camera"),
+      createDevice("extra-id", "Extra Camera")
+    ]);
+
+    await workbench.refreshDevicesFromDeviceChange();
+
+    const rerenderedVideos = currentVideos;
+    expect(rerenderedVideos).toBeDefined();
+    if (rerenderedVideos === undefined) {
+      throw new Error("rerendered preview videos should be installed");
+    }
+    expect(rerenderedVideos.frontVideo).not.toBe(initialVideos.frontVideo);
+    expect(rerenderedVideos.sideVideo).not.toBe(initialVideos.sideVideo);
+    rerenderedVideos.frontVideo.fireFrame();
+    rerenderedVideos.sideVideo.fireFrame();
+
+    await vi.waitFor(() => {
+      expect(frontTracker.detect).toHaveBeenCalledTimes(2);
+      expect(sideTracker.detect).toHaveBeenCalledTimes(2);
+    });
+    expect(createMediaPipeHandTrackerMock).toHaveBeenCalledTimes(2);
+    expect(frontTracker.cleanup).not.toHaveBeenCalled();
+    expect(sideTracker.cleanup).not.toHaveBeenCalled();
+  });
+
   it("preserves calibration when the same preview session re-renders fresh video elements", () => {
     const liveInspection = createLiveLandmarkInspection();
     const previewState = {

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -246,6 +246,45 @@ describe("renderWorkbenchHTML", () => {
     expect(html).toContain(`health: ${initialInspection.sideLaneHealth}`);
   });
 
+  it("renders captureLost as concise Japanese device loss copy while keeping raw health", () => {
+    const html = renderWorkbenchHTML(
+      createState({
+        screen: "previewing",
+        frontAssignment: {
+          role: "frontAim",
+          deviceId: "front-secret-device-id",
+          label: "Front Camera"
+        },
+        sideAssignment: {
+          role: "sideTrigger",
+          deviceId: "side-secret-device-id",
+          label: "Side Camera"
+        }
+      }),
+      {
+        frontDetection: undefined,
+        sideDetection: undefined,
+        frontLaneHealth: "captureLost",
+        sideLaneHealth: "tracking",
+        frontAimFrame: undefined,
+        frontAimTelemetry: undefined,
+        sideTriggerFrame: undefined,
+        sideTriggerTelemetry: undefined,
+        frontAimCalibration: defaultFrontAimCalibration,
+        sideTriggerCalibration: defaultSideTriggerCalibration,
+        sideTriggerTuning: defaultSideTriggerTuning,
+        fusionFrame: undefined,
+        fusionTelemetry: undefined,
+        fusionTuning: defaultFusionTuning
+      }
+    );
+
+    expect(html).toMatch(
+      /<p id="wb-front-health"[^>]*>health: captureLost \(カメラが切断されました\)<\/p>/
+    );
+    expect(html).not.toContain("front-secret-device-id");
+  });
+
   it("renders raw and filtered landmark inspection panes with timestamp readouts", () => {
     const html = renderWorkbenchHTML(
       createState({

--- a/tests/unit/features/input-fusion/createInputFusionMapper.test.ts
+++ b/tests/unit/features/input-fusion/createInputFusionMapper.test.ts
@@ -383,6 +383,42 @@ describe("createInputFusionMapper", () => {
     expect(bothFailed.sideSource.rejectReason).toBe("laneFailed");
   });
 
+  it("locks captureLost lane health to laneFailed without pairing stale opposite frames", () => {
+    const frontLostMapper = createInputFusionMapper();
+    frontLostMapper.updateAimFrame(createAimFrame(100), context);
+    const frontLost = frontLostMapper.updateTriggerUnavailable(
+      createTriggerFrame(116).timestamp,
+      {
+        ...context,
+        frontLaneHealth: "captureLost"
+      }
+    ).fusedFrame;
+
+    expect(frontLost.fusionRejectReason).toBe("laneFailed");
+    expect(frontLost.frontSource.laneHealth).toBe("captureLost");
+    expect(frontLost.frontSource.rejectReason).toBe("laneFailed");
+    expect(frontLost.fusionMode).not.toBe("pairedFrontAndSide");
+
+    const sideLostMapper = createInputFusionMapper();
+    sideLostMapper.updateTriggerFrame(
+      createTriggerFrame(100, { triggerEdge: "shotCommitted" }),
+      context
+    );
+    const sideLost = sideLostMapper.updateAimUnavailable(
+      createAimFrame(116).timestamp,
+      {
+        ...context,
+        sideLaneHealth: "captureLost"
+      }
+    ).fusedFrame;
+
+    expect(sideLost.fusionRejectReason).toBe("laneFailed");
+    expect(sideLost.sideSource.laneHealth).toBe("captureLost");
+    expect(sideLost.sideSource.rejectReason).toBe("laneFailed");
+    expect(sideLost.fusionMode).not.toBe("pairedFrontAndSide");
+    expect(sideLost.shotFired).toBe(false);
+  });
+
   it("resets affected buffers and side shot consumption independently", () => {
     const mapper = createInputFusionMapper();
     const sideCommit = createTriggerFrame(100, {


### PR DESCRIPTION
## Summary
- Add camera lifecycle observers for track ended and devicechange events, plus a small reconnect error budget.
- Convert lane track loss into captureLost health, stale fusion buffer clearing, and one-lane cleanup in both diagnostic workbench and game runtime.
- Add production-clean capture-lost HUD copy and camera reselect path while keeping diagnostic UI out of index.html.
- Preserve diagnostic calibration across same-device reconnect and reset it when a different device is selected.
- Commit the M9 implementation decomposition doc.

## Verification
- npm run check
- npm run test:e2e

Closes #9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/balloonshoot_v2/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New features**
  * Added "Camera disconnected" copy and a "Reselect camera" button to the HUD; the reselect flow lets the user choose an alternative camera.
  * Auto-refreshes the preview on devicechange detection and track-ended detection.
  * Introduced cooldown / budget control for reconnects.

* **Improvements**
  * Strengthened the disconnect UI / recovery flow with clean copy that does not leak internal information.

* **Documentation**
  * Added the implementation / verification plan.

* **Tests**
  * Added and expanded many E2E / integration / unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
