### PR TITLE
feat(iter): diagnostic capture recording (telemetry + video)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 *.tsbuildinfo
 test-results/
 playwright-report/
+recordings/
 
 # Benchmark fixtures — large webcam recordings kept out of git.
 # See tests/fixtures/videos/README.md for how to regenerate.

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -7,6 +7,7 @@ import {
 import { renderWorkbenchHTML } from "./features/diagnostic-workbench/renderWorkbench";
 import { createLiveLandmarkInspection } from "./features/diagnostic-workbench/liveLandmarkInspection";
 import { createSessionRecorder } from "./features/diagnostic-workbench/recording/sessionRecorder";
+import { formatRecordingTimer } from "./features/diagnostic-workbench/renderRecordingControls";
 
 const root = document.querySelector<HTMLDivElement>("#diagnostic-app");
 
@@ -44,6 +45,19 @@ const render = (): void => {
   syncRecordingTimer();
 };
 
+const updateRecordingTimer = (): void => {
+  const timerElement = document.querySelector<HTMLElement>(
+    "[data-recording-timer]"
+  );
+  const recordingState = recorder.getState();
+
+  if (timerElement === null || recordingState.status !== "recording") {
+    return;
+  }
+
+  timerElement.textContent = formatRecordingTimer(recordingState.elapsedMs);
+};
+
 const syncRecordingTimer = (): void => {
   const isRecording = recorder.getState().status === "recording";
 
@@ -52,7 +66,7 @@ const syncRecordingTimer = (): void => {
     recordingTimerId === undefined &&
     typeof window.setInterval === "function"
   ) {
-    recordingTimerId = window.setInterval(render, 1000);
+    recordingTimerId = window.setInterval(updateRecordingTimer, 1000);
     return;
   }
 

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -6,6 +6,7 @@ import {
 } from "./features/diagnostic-workbench/DiagnosticWorkbench";
 import { renderWorkbenchHTML } from "./features/diagnostic-workbench/renderWorkbench";
 import { createLiveLandmarkInspection } from "./features/diagnostic-workbench/liveLandmarkInspection";
+import { createSessionRecorder } from "./features/diagnostic-workbench/recording/sessionRecorder";
 
 const root = document.querySelector<HTMLDivElement>("#diagnostic-app");
 
@@ -13,8 +14,12 @@ if (!root) {
   throw new Error("Missing #diagnostic-app root");
 }
 
-const workbench: DiagnosticWorkbench = createDiagnosticWorkbench();
 const liveInspection = createLiveLandmarkInspection();
+const recorder = createSessionRecorder();
+const workbench: DiagnosticWorkbench = createDiagnosticWorkbench({
+  stopActiveRecording: () => recorder.stop()
+});
+let recordingTimerId: number | undefined;
 
 const runAction = (actionPromise: Promise<void>): void => {
   void actionPromise.catch((error: unknown) => {
@@ -28,10 +33,37 @@ const deviceChangeObserver = observeDeviceChange(() => {
 
 const render = (): void => {
   const state = workbench.getState();
-  root.innerHTML = renderWorkbenchHTML(state, liveInspection.getState());
+  root.innerHTML = renderWorkbenchHTML(
+    state,
+    liveInspection.getState(),
+    recorder.getState()
+  );
   attachVideoStreams(state);
   liveInspection.sync(state);
   liveInspection.updateDom();
+  syncRecordingTimer();
+};
+
+const syncRecordingTimer = (): void => {
+  const isRecording = recorder.getState().status === "recording";
+
+  if (
+    isRecording &&
+    recordingTimerId === undefined &&
+    typeof window.setInterval === "function"
+  ) {
+    recordingTimerId = window.setInterval(render, 1000);
+    return;
+  }
+
+  if (
+    !isRecording &&
+    recordingTimerId !== undefined &&
+    typeof window.clearInterval === "function"
+  ) {
+    window.clearInterval(recordingTimerId);
+    recordingTimerId = undefined;
+  }
 };
 
 const attachVideoStreams = (
@@ -130,6 +162,29 @@ const handleClick = (e: MouseEvent): void => {
       liveInspection.resetFusionTuning();
       render();
       break;
+    case "startRecording": {
+      const state = workbench.getState();
+
+      if (
+        state.screen !== "previewing" ||
+        state.frontStream === undefined ||
+        state.sideStream === undefined
+      ) {
+        return;
+      }
+
+      runAction(
+        recorder.start({
+          frontStream: state.frontStream.stream,
+          sideStream: state.sideStream.stream,
+          subscribeFrame: (callback) => liveInspection.subscribeFrame(callback)
+        })
+      );
+      break;
+    }
+    case "stopRecording":
+      runAction(recorder.stop());
+      break;
   }
 };
 
@@ -193,8 +248,17 @@ root.addEventListener("input", (e: Event) => {
   }
 });
 workbench.subscribe(render);
+recorder.subscribe(render);
 window.addEventListener("beforeunload", () => {
   deviceChangeObserver.stop();
+  if (
+    recordingTimerId !== undefined &&
+    typeof window.clearInterval === "function"
+  ) {
+    window.clearInterval(recordingTimerId);
+    recordingTimerId = undefined;
+  }
+  void recorder.destroy();
   liveInspection.destroy();
   workbench.destroy();
 });

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -263,7 +263,12 @@ root.addEventListener("input", (e: Event) => {
 });
 workbench.subscribe(render);
 recorder.subscribe(render);
-window.addEventListener("beforeunload", () => {
+// Use pagehide so recorder.destroy() can flush asynchronously on real unload.
+window.addEventListener("pagehide", (event) => {
+  if (event.persisted) {
+    return;
+  }
+
   deviceChangeObserver.stop();
   if (
     recordingTimerId !== undefined &&

--- a/src/diagnostic-main.ts
+++ b/src/diagnostic-main.ts
@@ -263,7 +263,18 @@ root.addEventListener("input", (e: Event) => {
 });
 workbench.subscribe(render);
 recorder.subscribe(render);
-// Use pagehide so recorder.destroy() can flush asynchronously on real unload.
+window.addEventListener("beforeunload", (event) => {
+  const status = recorder.getState().status;
+
+  if (status === "recording" || status === "starting" || status === "saving") {
+    event.preventDefault();
+    // Legacy browsers still use returnValue to trigger the native unload prompt.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    event.returnValue = "";
+    return "";
+  }
+});
+// Best-effort cleanup on real unload. Browsers do not wait for async flushing.
 window.addEventListener("pagehide", (event) => {
   if (event.persisted) {
     return;

--- a/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
+++ b/src/features/diagnostic-workbench/DiagnosticWorkbench.ts
@@ -77,7 +77,13 @@ export interface DiagnosticWorkbench {
   destroy(): void;
 }
 
-export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
+interface DiagnosticWorkbenchOptions {
+  readonly stopActiveRecording?: () => void | Promise<void>;
+}
+
+export const createDiagnosticWorkbench = (
+  options: DiagnosticWorkbenchOptions = {}
+): DiagnosticWorkbench => {
   let state: WorkbenchState = {
     screen: "permission",
     devices: [],
@@ -128,6 +134,12 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
 
   const stopCurrentStreams = (): void => {
     stopStreams(state.frontStream, state.sideStream);
+  };
+
+  const stopRecordingIfPreviewing = (): void => {
+    if (state.screen === "previewing") {
+      void options.stopActiveRecording?.();
+    }
   };
 
   const labelFor = (
@@ -337,6 +349,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       const frontLabel = labelFor(state.devices, frontId) ?? "Camera";
       const sideLabel = labelFor(state.devices, sideId) ?? "Camera";
 
+      stopRecordingIfPreviewing();
       stopStreams(previousFrontStream, previousSideStream);
 
       update({
@@ -503,6 +516,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       pendingDeviceRefreshAfterPermission = false;
       const myGeneration = requestGeneration;
 
+      stopRecordingIfPreviewing();
       stopCurrentStreams();
       update({
         screen: "permission",
@@ -617,6 +631,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       permissionEnumerationGeneration = undefined;
       pendingDeviceRefreshAfterPermission = false;
       const nextScreen = screenForDevices(state.devices);
+      stopRecordingIfPreviewing();
       stopCurrentStreams();
       update({
         screen: nextScreen,
@@ -638,6 +653,7 @@ export const createDiagnosticWorkbench = (): DiagnosticWorkbench => {
       permissionGranted = false;
       permissionEnumerationGeneration = undefined;
       pendingDeviceRefreshAfterPermission = false;
+      stopRecordingIfPreviewing();
       stopCurrentStreams();
       listeners.clear();
     }

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -62,6 +62,10 @@ import {
   formatLaneHealthLabel,
   type WorkbenchInspectionState
 } from "./renderWorkbench";
+import {
+  assembleTelemetryFrame,
+  type TelemetryFrame
+} from "./recording/telemetryFrame";
 import { formatFrameTimestamp } from "./timestampFormat";
 
 interface FrameTimingLike {
@@ -80,6 +84,7 @@ interface LaneTrackingOptions {
 
 interface LiveLandmarkInspection {
   getState(): WorkbenchInspectionState;
+  subscribeFrame(callback: (frame: TelemetryFrame) => void): () => void;
   sync(state: WorkbenchState): void;
   setFrontAimCalibration(key: FrontAimCalibrationKey, value: number): void;
   resetFrontAimCalibration(): void;
@@ -273,6 +278,7 @@ const sideCalibrationValueFor = (
 
 export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   let inspectionState = createInitialInspectionState();
+  const frameSubscribers = new Set<(frame: TelemetryFrame) => void>();
   let activeTracking: ActiveTracking | undefined;
   let frontAimMapper = createFrontAimMapper();
   let sideTriggerMapper: SideTriggerMapper = createSideTriggerMapper();
@@ -284,6 +290,18 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
   const setInspection = (patch: Partial<WorkbenchInspectionState>): void => {
     inspectionState = { ...inspectionState, ...patch };
     updateDom();
+  };
+
+  const emitTelemetryFrame = (timestamp: FrameTimestamp): void => {
+    const frame = assembleTelemetryFrame(inspectionState, timestamp);
+
+    if (frame === undefined) {
+      return;
+    }
+
+    for (const subscriber of frameSubscribers) {
+      subscriber(frame);
+    }
   };
 
   const updateDom = (): void => {
@@ -438,6 +456,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
         fusionFrame: fusionResult.fusedFrame,
         fusionTelemetry: fusionResult.telemetry
       });
+      emitTelemetryFrame(timestamp);
       return;
     }
 
@@ -466,6 +485,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       fusionFrame: fusionResult.fusedFrame,
       fusionTelemetry: fusionResult.telemetry
     });
+    emitTelemetryFrame(timestamp);
   };
 
   const runLaneDetection = async (
@@ -614,11 +634,9 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       }
 
       if (typeof video.requestVideoFrameCallback === "function") {
-        callbackId = video.requestVideoFrameCallback(
-          (_now, metadata) => {
-            void processFrame(metadata);
-          }
-        );
+        callbackId = video.requestVideoFrameCallback((_now, metadata) => {
+          void processFrame(metadata);
+        });
         return;
       }
 
@@ -845,6 +863,12 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     getState() {
       return inspectionState;
     },
+    subscribeFrame(callback) {
+      frameSubscribers.add(callback);
+      return () => {
+        frameSubscribers.delete(callback);
+      };
+    },
     sync,
     setFrontAimCalibration(key, value) {
       const metadata = FRONT_AIM_CALIBRATION_SLIDER_METADATA.find(
@@ -935,6 +959,7 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
     updateDom,
     destroy() {
       stopActiveTracking();
+      frameSubscribers.clear();
       resetTrackingState({ resetCalibration: true });
       lastPreviewDeviceIds = undefined;
     }

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -58,15 +58,13 @@ import { renderFusionPanel } from "./renderFusionPanel";
 import { renderSideTriggerCalibrationControls } from "./renderSideTriggerCalibrationControls";
 import { renderSideTriggerPanel } from "./renderSideTriggerPanel";
 import { renderSideWorldLandmarks } from "./renderWorldLandmarks";
-import {
-  formatLaneHealthLabel,
-  type WorkbenchInspectionState
-} from "./renderWorkbench";
+import { formatLaneHealthLabel } from "./renderWorkbench";
 import {
   assembleTelemetryFrame,
   type TelemetryFrame
 } from "./recording/telemetryFrame";
 import { formatFrameTimestamp } from "./timestampFormat";
+import type { WorkbenchInspectionState } from "./workbenchInspectionState";
 
 interface FrameTimingLike {
   readonly captureTime?: number;

--- a/src/features/diagnostic-workbench/liveLandmarkInspection.ts
+++ b/src/features/diagnostic-workbench/liveLandmarkInspection.ts
@@ -115,6 +115,8 @@ interface LaneTracking {
 const createInitialInspectionState = (): WorkbenchInspectionState => ({
   frontDetection: undefined,
   sideDetection: undefined,
+  frontFrameTimestamp: undefined,
+  sideFrameTimestamp: undefined,
   frontLaneHealth: "notStarted",
   sideLaneHealth: "notStarted",
   frontAimFrame: undefined,
@@ -297,8 +299,23 @@ export const createLiveLandmarkInspection = (): LiveLandmarkInspection => {
       return;
     }
 
+    let subscriberIndex = 0;
+
     for (const subscriber of frameSubscribers) {
-      subscriber(frame);
+      try {
+        subscriber(frame);
+      } catch (error: unknown) {
+        console.error(
+          "Diagnostic telemetry subscriber failed",
+          {
+            subscriberIndex,
+            subscriberName: subscriber.name || "anonymous"
+          },
+          error
+        );
+      }
+
+      subscriberIndex += 1;
     }
   };
 

--- a/src/features/diagnostic-workbench/recording/AGENTS.md
+++ b/src/features/diagnostic-workbench/recording/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## WHY
+
+- `recording/` owns diagnostic workbench capture output for calibration iteration.
+
+## WHAT
+
+- Session coordination for telemetry JSON and WebM video capture
+- File System Access API writes into a user-picked directory
+- Pure helpers for telemetry frame assembly and JSON rotation
+
+## HOW
+
+- Keep recording workbench-level; never import this directory from game pages or lane modules.
+- Do not persist directory handles outside the current workbench session.
+- Treat video streams as start-time captures; telemetry follows the live diagnostic frame subscription.

--- a/src/features/diagnostic-workbench/recording/CLAUDE.md
+++ b/src/features/diagnostic-workbench/recording/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/features/diagnostic-workbench/recording/jsonRotation.ts
+++ b/src/features/diagnostic-workbench/recording/jsonRotation.ts
@@ -1,0 +1,10 @@
+const TELEMETRY_JSON_PATTERN = /^telemetry-.*\.json$/;
+
+export const telemetryJsonFilesToDelete = (
+  names: readonly string[],
+  capacity: number
+): string[] =>
+  names
+    .filter((name) => TELEMETRY_JSON_PATTERN.test(name))
+    .sort((a, b) => b.localeCompare(a))
+    .slice(Math.max(0, capacity));

--- a/src/features/diagnostic-workbench/recording/jsonRotation.ts
+++ b/src/features/diagnostic-workbench/recording/jsonRotation.ts
@@ -1,4 +1,5 @@
-const TELEMETRY_JSON_PATTERN = /^telemetry-.*\.json$/;
+const TELEMETRY_JSON_PATTERN =
+  /^telemetry-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.json$/;
 
 export const telemetryJsonFilesToDelete = (
   names: readonly string[],

--- a/src/features/diagnostic-workbench/recording/sessionRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/sessionRecorder.ts
@@ -2,10 +2,11 @@ import { telemetryJsonFilesToDelete } from "./jsonRotation";
 import { createStreamRecorder, type StreamRecorder } from "./streamRecorder";
 import type { TelemetryFrame, TelemetrySessionJson } from "./telemetryFrame";
 
-type RecordingStatus = "idle" | "recording" | "saving" | "error";
+type RecordingStatus = "idle" | "starting" | "recording" | "saving" | "error";
 
 export type RecordingState =
   | { readonly status: Extract<RecordingStatus, "idle"> }
+  | { readonly status: Extract<RecordingStatus, "starting"> }
   | {
       readonly status: Extract<RecordingStatus, "recording">;
       readonly elapsedMs: number;
@@ -247,9 +248,11 @@ export const createSessionRecorder = ({
     },
 
     async start(options) {
-      if (state.status === "recording" || state.status === "saving") {
+      if (state.status !== "idle") {
         return;
       }
+
+      setState({ status: "starting" });
 
       try {
         directoryHandle = await ensureWritableDirectory(

--- a/src/features/diagnostic-workbench/recording/sessionRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/sessionRecorder.ts
@@ -155,7 +155,11 @@ export const createSessionRecorder = ({
 
   const emit = (): void => {
     for (const listener of listeners) {
-      listener(state);
+      try {
+        listener(state);
+      } catch (error: unknown) {
+        console.error("[diagnostic recording] state listener threw", error);
+      }
     }
   };
 
@@ -248,10 +252,11 @@ export const createSessionRecorder = ({
     },
 
     async start(options) {
-      if (state.status !== "idle") {
+      if (state.status !== "idle" && state.status !== "error") {
         return;
       }
 
+      resetSession();
       setState({ status: "starting" });
 
       try {

--- a/src/features/diagnostic-workbench/recording/sessionRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/sessionRecorder.ts
@@ -47,6 +47,12 @@ interface SessionRecorderOptions {
 
 const JSON_ROTATION_CAPACITY = 10;
 
+class StartCancelledError extends Error {
+  constructor() {
+    super("Session recording start was cancelled");
+  }
+}
+
 interface DirectoryPickerWindow extends Window {
   showDirectoryPicker?: (options: {
     readonly mode: "readwrite";
@@ -152,6 +158,7 @@ export const createSessionRecorder = ({
   let sideRecorder: StreamRecorder | undefined;
   let unsubscribeFrame: (() => void) | undefined;
   let acceptingFrames = false;
+  let startGeneration = 0;
 
   const emit = (): void => {
     for (const listener of listeners) {
@@ -196,6 +203,36 @@ export const createSessionRecorder = ({
     });
 
     await Promise.all(stopPromises);
+  };
+
+  const isStartCancelled = (generation: number): boolean =>
+    generation !== startGeneration;
+
+  const resetCancelledStart = (): void => {
+    if (state.status === "idle") {
+      resetSession();
+    }
+  };
+
+  const throwIfStartCancelled = (generation: number): void => {
+    if (isStartCancelled(generation)) {
+      resetCancelledStart();
+      throw new StartCancelledError();
+    }
+  };
+
+  const stopStartedRecordersIfCancelled = async (
+    generation: number,
+    recorders: readonly StreamRecorder[],
+    startResults: readonly PromiseSettledResult<void>[]
+  ): Promise<void> => {
+    if (!isStartCancelled(generation)) {
+      return;
+    }
+
+    await stopStartedRecorders(recorders, startResults);
+    resetCancelledStart();
+    throw new StartCancelledError();
   };
 
   const flushTelemetry = async (
@@ -256,6 +293,7 @@ export const createSessionRecorder = ({
         return;
       }
 
+      const myGeneration = ++startGeneration;
       resetSession();
       setState({ status: "starting" });
 
@@ -264,12 +302,18 @@ export const createSessionRecorder = ({
           directoryHandle,
           requestDirectoryHandle
         );
+        throwIfStartCancelled(myGeneration);
+
         const frontFile = await directoryHandle.getFileHandle("front.webm", {
           create: true
         });
+        throwIfStartCancelled(myGeneration);
+
         const sideFile = await directoryHandle.getFileHandle("side.webm", {
           create: true
         });
+        throwIfStartCancelled(myGeneration);
+
         frontRecorder = createVideoRecorder({
           stream: options.frontStream,
           fileHandle: frontFile
@@ -282,6 +326,12 @@ export const createSessionRecorder = ({
         const startResults = await Promise.allSettled(
           recorders.map((recorder) => recorder.start())
         );
+        await stopStartedRecordersIfCancelled(
+          myGeneration,
+          recorders,
+          startResults
+        );
+
         const startFailure = startResults.find(
           (result): result is PromiseRejectedResult =>
             result.status === "rejected"
@@ -300,8 +350,17 @@ export const createSessionRecorder = ({
             frames.push(frame);
           }
         });
+
         setState({ status: "recording", elapsedMs: 0 });
       } catch (error: unknown) {
+        if (
+          error instanceof StartCancelledError ||
+          isStartCancelled(myGeneration)
+        ) {
+          resetCancelledStart();
+          return;
+        }
+
         resetSession();
         setState({
           status: "error",
@@ -311,6 +370,14 @@ export const createSessionRecorder = ({
     },
 
     async stop() {
+      startGeneration += 1;
+
+      if (state.status === "starting") {
+        resetSession();
+        setState({ status: "idle" });
+        return;
+      }
+
       if (state.status !== "recording") {
         return;
       }

--- a/src/features/diagnostic-workbench/recording/sessionRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/sessionRecorder.ts
@@ -64,20 +64,17 @@ type PermissionedDirectoryHandle = FileSystemDirectoryHandle & {
 };
 
 const requestDirectoryPicker = (): Promise<FileSystemDirectoryHandle> => {
-  const picker = (window as DirectoryPickerWindow).showDirectoryPicker;
+  const w = window as DirectoryPickerWindow;
 
-  if (typeof picker !== "function") {
+  if (typeof w.showDirectoryPicker !== "function") {
     throw new Error("File System Access API is unavailable in this browser");
   }
 
-  return picker({ mode: "readwrite" });
+  return w.showDirectoryPicker({ mode: "readwrite" });
 };
 
 const isoTimestampForFilename = (date: Date): string =>
-  date
-    .toISOString()
-    .replace(/\.\d{3}Z$/, "Z")
-    .replaceAll(":", "-");
+  date.toISOString().replace(".", "-").replaceAll(":", "-");
 
 const createTelemetryFileName = (date: Date): string =>
   `telemetry-${isoTimestampForFilename(date)}.json`;
@@ -179,6 +176,23 @@ export const createSessionRecorder = ({
     await Promise.all([frontRecorder?.stop(), sideRecorder?.stop()]);
   };
 
+  const stopStartedRecorders = async (
+    recorders: readonly StreamRecorder[],
+    startResults: readonly PromiseSettledResult<void>[]
+  ): Promise<void> => {
+    const stopPromises = startResults.flatMap((result, index) => {
+      const recorder = recorders[index];
+
+      if (result.status !== "fulfilled" || recorder === undefined) {
+        return [];
+      }
+
+      return [recorder.stop().catch(() => undefined)];
+    });
+
+    await Promise.all(stopPromises);
+  };
+
   const flushTelemetry = async (
     directory: FileSystemDirectoryHandle,
     startedAt: Date,
@@ -256,7 +270,20 @@ export const createSessionRecorder = ({
           stream: options.sideStream,
           fileHandle: sideFile
         });
-        await Promise.all([frontRecorder.start(), sideRecorder.start()]);
+        const recorders = [frontRecorder, sideRecorder] as const;
+        const startResults = await Promise.allSettled(
+          recorders.map((recorder) => recorder.start())
+        );
+        const startFailure = startResults.find(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected"
+        );
+
+        if (startFailure !== undefined) {
+          await stopStartedRecorders(recorders, startResults);
+          throw startFailure.reason;
+        }
+
         frames = [];
         sessionStart = now();
         acceptingFrames = true;

--- a/src/features/diagnostic-workbench/recording/sessionRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/sessionRecorder.ts
@@ -1,0 +1,315 @@
+import { telemetryJsonFilesToDelete } from "./jsonRotation";
+import { createStreamRecorder, type StreamRecorder } from "./streamRecorder";
+import type { TelemetryFrame, TelemetrySessionJson } from "./telemetryFrame";
+
+type RecordingStatus = "idle" | "recording" | "saving" | "error";
+
+export type RecordingState =
+  | { readonly status: Extract<RecordingStatus, "idle"> }
+  | {
+      readonly status: Extract<RecordingStatus, "recording">;
+      readonly elapsedMs: number;
+    }
+  | { readonly status: Extract<RecordingStatus, "saving"> }
+  | {
+      readonly status: Extract<RecordingStatus, "error">;
+      readonly message: string;
+    };
+
+export type DiagnosticFrameSubscription = (
+  callback: (frame: TelemetryFrame) => void
+) => () => void;
+
+interface SessionRecorderStartOptions {
+  readonly frontStream: MediaStream;
+  readonly sideStream: MediaStream;
+  readonly subscribeFrame: DiagnosticFrameSubscription;
+}
+
+interface SessionRecorder {
+  getState(): RecordingState;
+  subscribe(listener: (state: RecordingState) => void): () => void;
+  isRecording(): boolean;
+  start(options: SessionRecorderStartOptions): Promise<void>;
+  stop(): Promise<void>;
+  destroy(): Promise<void>;
+}
+
+interface SessionRecorderOptions {
+  readonly requestDirectoryHandle?: () => Promise<FileSystemDirectoryHandle>;
+  readonly createVideoRecorder?: (options: {
+    readonly stream: MediaStream;
+    readonly fileHandle: FileSystemFileHandle;
+  }) => StreamRecorder;
+  readonly now?: () => Date;
+}
+
+const JSON_ROTATION_CAPACITY = 10;
+
+interface DirectoryPickerWindow extends Window {
+  showDirectoryPicker?: (options: {
+    readonly mode: "readwrite";
+  }) => Promise<FileSystemDirectoryHandle>;
+}
+
+type PermissionedDirectoryHandle = FileSystemDirectoryHandle & {
+  queryPermission(options: {
+    readonly mode: "readwrite";
+  }): Promise<PermissionState>;
+  requestPermission(options: {
+    readonly mode: "readwrite";
+  }): Promise<PermissionState>;
+  deleteEntry(name: string): Promise<void>;
+  entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+};
+
+const requestDirectoryPicker = (): Promise<FileSystemDirectoryHandle> => {
+  const picker = (window as DirectoryPickerWindow).showDirectoryPicker;
+
+  if (typeof picker !== "function") {
+    throw new Error("File System Access API is unavailable in this browser");
+  }
+
+  return picker({ mode: "readwrite" });
+};
+
+const isoTimestampForFilename = (date: Date): string =>
+  date
+    .toISOString()
+    .replace(/\.\d{3}Z$/, "Z")
+    .replaceAll(":", "-");
+
+const createTelemetryFileName = (date: Date): string =>
+  `telemetry-${isoTimestampForFilename(date)}.json`;
+
+const ensureWritableDirectory = async (
+  currentHandle: FileSystemDirectoryHandle | undefined,
+  requestDirectoryHandle: () => Promise<FileSystemDirectoryHandle>
+): Promise<FileSystemDirectoryHandle> => {
+  if (currentHandle === undefined) {
+    return requestDirectoryHandle();
+  }
+
+  const handle = currentHandle as PermissionedDirectoryHandle;
+  const permission = await handle.queryPermission({
+    mode: "readwrite"
+  });
+
+  if (permission === "granted") {
+    return currentHandle;
+  }
+
+  if (permission === "prompt") {
+    const requested = await handle.requestPermission({
+      mode: "readwrite"
+    });
+
+    if (requested === "granted") {
+      return currentHandle;
+    }
+  }
+
+  return requestDirectoryHandle();
+};
+
+const listDirectoryNames = async (
+  directory: FileSystemDirectoryHandle
+): Promise<string[]> => {
+  const names: string[] = [];
+
+  for await (const [name] of (
+    directory as PermissionedDirectoryHandle
+  ).entries()) {
+    names.push(name);
+  }
+
+  return names;
+};
+
+const writeJsonFile = async (
+  fileHandle: FileSystemFileHandle,
+  payload: TelemetrySessionJson
+): Promise<void> => {
+  const writable = await fileHandle.createWritable();
+
+  try {
+    await writable.write(JSON.stringify(payload, null, 2));
+  } finally {
+    await writable.close();
+  }
+};
+
+export const createSessionRecorder = ({
+  requestDirectoryHandle = requestDirectoryPicker,
+  createVideoRecorder = ({ stream, fileHandle }) =>
+    createStreamRecorder({ stream, fileHandle }),
+  now = () => new Date()
+}: SessionRecorderOptions = {}): SessionRecorder => {
+  let directoryHandle: FileSystemDirectoryHandle | undefined;
+  let state: RecordingState = { status: "idle" };
+  const listeners = new Set<(state: RecordingState) => void>();
+  let frames: TelemetryFrame[] = [];
+  let sessionStart: Date | undefined;
+  let frontRecorder: StreamRecorder | undefined;
+  let sideRecorder: StreamRecorder | undefined;
+  let unsubscribeFrame: (() => void) | undefined;
+  let acceptingFrames = false;
+
+  const emit = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const setState = (next: RecordingState): void => {
+    state = next;
+    emit();
+  };
+
+  const resetSession = (): void => {
+    frames = [];
+    sessionStart = undefined;
+    frontRecorder = undefined;
+    sideRecorder = undefined;
+    unsubscribeFrame = undefined;
+    acceptingFrames = false;
+  };
+
+  const stopVideoRecorders = async (): Promise<void> => {
+    await Promise.all([frontRecorder?.stop(), sideRecorder?.stop()]);
+  };
+
+  const flushTelemetry = async (
+    directory: FileSystemDirectoryHandle,
+    startedAt: Date,
+    endedAt: Date,
+    capturedFrames: readonly TelemetryFrame[]
+  ): Promise<void> => {
+    const fileHandle = await directory.getFileHandle(
+      createTelemetryFileName(startedAt),
+      { create: true }
+    );
+    await writeJsonFile(fileHandle, {
+      schemaVersion: 1,
+      sessionStart: startedAt.toISOString(),
+      sessionEnd: endedAt.toISOString(),
+      frames: capturedFrames
+    });
+
+    const names = await listDirectoryNames(directory);
+    const namesToDelete = telemetryJsonFilesToDelete(
+      names,
+      JSON_ROTATION_CAPACITY
+    );
+
+    await Promise.all(
+      namesToDelete.map((name) =>
+        (directory as PermissionedDirectoryHandle).deleteEntry(name)
+      )
+    );
+  };
+
+  return {
+    getState() {
+      if (state.status !== "recording" || sessionStart === undefined) {
+        return state;
+      }
+
+      return {
+        status: "recording",
+        elapsedMs: Math.max(0, now().getTime() - sessionStart.getTime())
+      };
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    isRecording() {
+      return state.status === "recording";
+    },
+
+    async start(options) {
+      if (state.status === "recording" || state.status === "saving") {
+        return;
+      }
+
+      try {
+        directoryHandle = await ensureWritableDirectory(
+          directoryHandle,
+          requestDirectoryHandle
+        );
+        const frontFile = await directoryHandle.getFileHandle("front.webm", {
+          create: true
+        });
+        const sideFile = await directoryHandle.getFileHandle("side.webm", {
+          create: true
+        });
+        frontRecorder = createVideoRecorder({
+          stream: options.frontStream,
+          fileHandle: frontFile
+        });
+        sideRecorder = createVideoRecorder({
+          stream: options.sideStream,
+          fileHandle: sideFile
+        });
+        await Promise.all([frontRecorder.start(), sideRecorder.start()]);
+        frames = [];
+        sessionStart = now();
+        acceptingFrames = true;
+        unsubscribeFrame = options.subscribeFrame((frame) => {
+          if (acceptingFrames) {
+            frames.push(frame);
+          }
+        });
+        setState({ status: "recording", elapsedMs: 0 });
+      } catch (error: unknown) {
+        resetSession();
+        setState({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error)
+        });
+      }
+    },
+
+    async stop() {
+      if (state.status !== "recording") {
+        return;
+      }
+
+      const directory = directoryHandle;
+      const startedAt = sessionStart;
+      const capturedFrames = [...frames];
+      acceptingFrames = false;
+      unsubscribeFrame?.();
+      unsubscribeFrame = undefined;
+      setState({ status: "saving" });
+
+      try {
+        await stopVideoRecorders();
+
+        if (directory === undefined || startedAt === undefined) {
+          throw new Error("Recording session was not initialized");
+        }
+
+        await flushTelemetry(directory, startedAt, now(), capturedFrames);
+        resetSession();
+        setState({ status: "idle" });
+      } catch (error: unknown) {
+        resetSession();
+        setState({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error)
+        });
+      }
+    },
+
+    async destroy() {
+      await this.stop();
+      listeners.clear();
+    }
+  };
+};

--- a/src/features/diagnostic-workbench/recording/streamRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/streamRecorder.ts
@@ -50,6 +50,16 @@ export const createStreamRecorder = ({
   let started = false;
   let stopped = false;
 
+  const resetPartialState = (): void => {
+    writable = undefined;
+    mediaRecorder = undefined;
+    pendingWrite = Promise.resolve();
+    writeError = undefined;
+    acceptingChunks = false;
+    started = false;
+    stopped = false;
+  };
+
   const enqueueWrite = (blob: Blob): void => {
     if (!acceptingChunks || blob.size === 0 || writable === undefined) {
       return;
@@ -69,18 +79,32 @@ export const createStreamRecorder = ({
         return;
       }
 
-      writable = await fileHandle.createWritable();
-      const mimeType = selectWebmMimeType(isTypeSupported);
-      mediaRecorder = mediaRecorderFactory(
-        stream,
-        mimeType === undefined ? undefined : { mimeType }
-      );
-      mediaRecorder.ondataavailable = (event) => {
-        enqueueWrite(event.data);
-      };
-      acceptingChunks = true;
-      started = true;
-      mediaRecorder.start();
+      let nextWritable: FileSystemWritableFileStream | undefined;
+
+      try {
+        const mimeType = selectWebmMimeType(isTypeSupported);
+        mediaRecorder = mediaRecorderFactory(
+          stream,
+          mimeType === undefined ? undefined : { mimeType }
+        );
+        nextWritable = await fileHandle.createWritable();
+        writable = nextWritable;
+        mediaRecorder.ondataavailable = (event) => {
+          enqueueWrite(event.data);
+        };
+        mediaRecorder.start();
+        acceptingChunks = true;
+        started = true;
+        stopped = false;
+      } catch (error: unknown) {
+        try {
+          await nextWritable?.close();
+        } catch {
+          // Best-effort cleanup must not mask the original start failure.
+        }
+        resetPartialState();
+        throw error;
+      }
     },
 
     async stop() {
@@ -89,13 +113,27 @@ export const createStreamRecorder = ({
       }
 
       stopped = true;
-      acceptingChunks = false;
 
       if (mediaRecorder?.state === "recording") {
-        mediaRecorder.stop();
+        await new Promise<void>((resolve) => {
+          const previousOnStop = mediaRecorder?.onstop ?? null;
+          const recorder = mediaRecorder;
+
+          if (recorder === undefined) {
+            resolve();
+            return;
+          }
+
+          recorder.onstop = function (event) {
+            previousOnStop?.call(this, event);
+            resolve();
+          };
+          recorder.stop();
+        });
       }
 
       await pendingWrite;
+      acceptingChunks = false;
 
       try {
         await writable?.close();

--- a/src/features/diagnostic-workbench/recording/streamRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/streamRecorder.ts
@@ -1,0 +1,113 @@
+export interface StreamRecorder {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+type MediaRecorderFactory = (
+  stream: MediaStream,
+  options?: MediaRecorderOptions
+) => MediaRecorder;
+
+interface StreamRecorderOptions {
+  readonly stream: MediaStream;
+  readonly fileHandle: FileSystemFileHandle;
+  readonly mediaRecorderFactory?: MediaRecorderFactory;
+  readonly isTypeSupported?: (mimeType: string) => boolean;
+}
+
+const WEBM_MIME_TYPE_CANDIDATES = [
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm"
+] as const;
+
+const defaultMediaRecorderFactory: MediaRecorderFactory = (stream, options) =>
+  new MediaRecorder(stream, options);
+
+const defaultIsTypeSupported = (mimeType: string): boolean =>
+  typeof MediaRecorder !== "undefined" &&
+  MediaRecorder.isTypeSupported(mimeType);
+
+const selectWebmMimeType = (
+  isTypeSupported: (mimeType: string) => boolean
+): string | undefined =>
+  WEBM_MIME_TYPE_CANDIDATES.find((mimeType) => isTypeSupported(mimeType));
+
+const errorMessageFor = (error: unknown): string =>
+  typeof error === "string" ? error : "Stream recorder write failed";
+
+export const createStreamRecorder = ({
+  stream,
+  fileHandle,
+  mediaRecorderFactory = defaultMediaRecorderFactory,
+  isTypeSupported = defaultIsTypeSupported
+}: StreamRecorderOptions): StreamRecorder => {
+  let writable: FileSystemWritableFileStream | undefined;
+  let mediaRecorder: MediaRecorder | undefined;
+  let pendingWrite: Promise<void> = Promise.resolve();
+  let writeError: unknown;
+  let acceptingChunks = false;
+  let started = false;
+  let stopped = false;
+
+  const enqueueWrite = (blob: Blob): void => {
+    if (!acceptingChunks || blob.size === 0 || writable === undefined) {
+      return;
+    }
+
+    pendingWrite = pendingWrite
+      .then(() => writable?.write(blob))
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        writeError = error;
+      });
+  };
+
+  return {
+    async start() {
+      if (started) {
+        return;
+      }
+
+      writable = await fileHandle.createWritable();
+      const mimeType = selectWebmMimeType(isTypeSupported);
+      mediaRecorder = mediaRecorderFactory(
+        stream,
+        mimeType === undefined ? undefined : { mimeType }
+      );
+      mediaRecorder.ondataavailable = (event) => {
+        enqueueWrite(event.data);
+      };
+      acceptingChunks = true;
+      started = true;
+      mediaRecorder.start();
+    },
+
+    async stop() {
+      if (!started || stopped) {
+        return;
+      }
+
+      stopped = true;
+      acceptingChunks = false;
+
+      if (mediaRecorder?.state === "recording") {
+        mediaRecorder.stop();
+      }
+
+      await pendingWrite;
+
+      try {
+        await writable?.close();
+      } finally {
+        writable = undefined;
+      }
+
+      if (writeError !== undefined) {
+        throw writeError instanceof Error
+          ? writeError
+          : new Error(errorMessageFor(writeError));
+      }
+    }
+  };
+};

--- a/src/features/diagnostic-workbench/recording/streamRecorder.ts
+++ b/src/features/diagnostic-workbench/recording/streamRecorder.ts
@@ -20,6 +20,7 @@ const WEBM_MIME_TYPE_CANDIDATES = [
   "video/webm;codecs=vp8",
   "video/webm"
 ] as const;
+const MEDIA_RECORDER_TIMESLICE_MS = 1000;
 
 const defaultMediaRecorderFactory: MediaRecorderFactory = (stream, options) =>
   new MediaRecorder(stream, options);
@@ -92,8 +93,9 @@ export const createStreamRecorder = ({
         mediaRecorder.ondataavailable = (event) => {
           enqueueWrite(event.data);
         };
-        mediaRecorder.start();
         acceptingChunks = true;
+        // 1s timeslice: bound memory, flush incrementally, preserve crash recovery.
+        mediaRecorder.start(MEDIA_RECORDER_TIMESLICE_MS);
         started = true;
         stopped = false;
       } catch (error: unknown) {

--- a/src/features/diagnostic-workbench/recording/telemetryFrame.ts
+++ b/src/features/diagnostic-workbench/recording/telemetryFrame.ts
@@ -21,7 +21,7 @@ import type {
   SideTriggerPhase,
   TriggerEdge
 } from "../../../shared/types/trigger";
-import type { WorkbenchInspectionState } from "../renderWorkbench";
+import type { WorkbenchInspectionState } from "../workbenchInspectionState";
 
 export interface TelemetryFrame {
   readonly timestamp: FrameTimestamp;

--- a/src/features/diagnostic-workbench/recording/telemetryFrame.ts
+++ b/src/features/diagnostic-workbench/recording/telemetryFrame.ts
@@ -1,0 +1,145 @@
+import type { FrontAimCalibration } from "../../front-aim";
+import type { SideTriggerEvidence } from "../../side-trigger/sideTriggerEvidence";
+import type { SideTriggerCalibration } from "../../side-trigger";
+import type {
+  FrontAimTelemetry,
+  FrontAimTelemetryUnavailable
+} from "../../../shared/types/aim";
+import type {
+  FrameTimestamp,
+  LaneHealthStatus
+} from "../../../shared/types/camera";
+import type {
+  FusionMode,
+  FusedGameInputFrame
+} from "../../../shared/types/fusion";
+import type {
+  HandLandmarkSet,
+  SideViewQuality
+} from "../../../shared/types/hand";
+import type {
+  SideTriggerPhase,
+  TriggerEdge
+} from "../../../shared/types/trigger";
+import type { WorkbenchInspectionState } from "../renderWorkbench";
+
+export interface TelemetryFrame {
+  readonly timestamp: FrameTimestamp;
+  readonly fusionMode: FusionMode;
+  readonly calibration: {
+    readonly frontAim: FrontAimCalibration;
+    readonly sideTrigger: SideTriggerCalibration;
+  };
+  readonly front: {
+    readonly landmarks: HandLandmarkSet | undefined;
+    readonly laneHealth: LaneHealthStatus;
+    readonly aimContext: FrontAimTelemetry | undefined;
+  };
+  readonly side: {
+    readonly landmarks: HandLandmarkSet | undefined;
+    readonly worldLandmarks: HandLandmarkSet | undefined;
+    readonly sideViewQuality: SideViewQuality;
+    readonly evidence: SideTriggerEvidence;
+    readonly fsmPhase: SideTriggerPhase;
+    readonly triggerEdge: TriggerEdge | undefined;
+    readonly laneHealth: LaneHealthStatus;
+  };
+  readonly fusion: FusedGameInputFrame;
+}
+
+export interface TelemetrySessionJson {
+  readonly schemaVersion: 1;
+  readonly sessionStart: string;
+  readonly sessionEnd: string;
+  readonly frames: readonly TelemetryFrame[];
+}
+
+const unavailableAimContext = (
+  state: WorkbenchInspectionState
+): FrontAimTelemetryUnavailable => ({
+  aimAvailability: "unavailable",
+  aimSmoothingState: "coldStart",
+  frontHandDetected: false,
+  frontTrackingConfidence: undefined,
+  aimPointViewport: undefined,
+  aimPointNormalized: undefined,
+  sourceFrameSize: undefined,
+  calibrationStatus: "liveTuning",
+  calibration: state.frontAimCalibration,
+  lastLostReason: "handNotDetected"
+});
+
+const evidenceFromInspection = (
+  state: WorkbenchInspectionState
+): SideTriggerEvidence => {
+  const telemetry = state.sideTriggerTelemetry;
+
+  if (telemetry === undefined) {
+    return {
+      sideHandDetected: false,
+      sideViewQuality: state.sideDetection?.sideViewQuality ?? "lost",
+      pullEvidenceScalar: 0,
+      releaseEvidenceScalar: 0,
+      triggerPostureConfidence: 0,
+      shotCandidateConfidence: 0,
+      rejectReason: "handNotDetected",
+      usedWorldLandmarks: false
+    };
+  }
+
+  return {
+    sideHandDetected: state.sideTriggerFrame?.sideHandDetected ?? false,
+    sideViewQuality: state.sideDetection?.sideViewQuality ?? "lost",
+    pullEvidenceScalar: telemetry.pullEvidenceScalar,
+    releaseEvidenceScalar: telemetry.releaseEvidenceScalar,
+    triggerPostureConfidence: telemetry.triggerPostureConfidence,
+    shotCandidateConfidence: telemetry.shotCandidateConfidence,
+    rejectReason: telemetry.lastRejectReason,
+    usedWorldLandmarks: telemetry.usedWorldLandmarks
+  };
+};
+
+const triggerEdgeFromInspection = (
+  state: WorkbenchInspectionState
+): TriggerEdge | undefined => {
+  const edge =
+    state.sideTriggerTelemetry?.edge ?? state.sideTriggerFrame?.triggerEdge;
+
+  return edge === undefined || edge === "none" ? undefined : edge;
+};
+
+export const assembleTelemetryFrame = (
+  state: WorkbenchInspectionState,
+  timestamp: FrameTimestamp
+): TelemetryFrame | undefined => {
+  if (state.fusionFrame === undefined) {
+    return undefined;
+  }
+
+  return {
+    timestamp,
+    fusionMode: state.fusionFrame.fusionMode,
+    calibration: {
+      frontAim: state.frontAimCalibration,
+      sideTrigger: state.sideTriggerCalibration
+    },
+    front: {
+      landmarks: state.frontDetection?.rawFrame.landmarks,
+      laneHealth: state.frontLaneHealth,
+      aimContext: state.frontAimTelemetry ?? unavailableAimContext(state)
+    },
+    side: {
+      landmarks: state.sideDetection?.rawFrame.landmarks,
+      worldLandmarks: state.sideDetection?.rawFrame.worldLandmarks,
+      sideViewQuality: state.sideDetection?.sideViewQuality ?? "lost",
+      evidence: evidenceFromInspection(state),
+      fsmPhase:
+        state.sideTriggerTelemetry?.phase ??
+        state.sideTriggerFrame?.sideTriggerPhase ??
+        "SideTriggerNoHand",
+      triggerEdge: triggerEdgeFromInspection(state),
+      laneHealth: state.sideLaneHealth
+    },
+    fusion: state.fusionFrame
+  };
+};

--- a/src/features/diagnostic-workbench/renderRecordingControls.ts
+++ b/src/features/diagnostic-workbench/renderRecordingControls.ts
@@ -1,0 +1,44 @@
+import { escapeHTML } from "../../shared/browser/escapeHTML";
+import type { RecordingState } from "./recording/sessionRecorder";
+
+const formatTimer = (elapsedMs: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+};
+
+const renderAction = (state: RecordingState): string => {
+  switch (state.status) {
+    case "recording":
+      return `<button class="wb-btn wb-recording-stop" data-wb-action="stopRecording">Stop</button>`;
+    case "saving":
+      return `<button class="wb-btn wb-btn-secondary" disabled>Saving</button>`;
+    case "idle":
+    case "error":
+      return `<button class="wb-btn" data-wb-action="startRecording">Record</button>`;
+  }
+};
+
+const renderTimer = (state: RecordingState): string =>
+  state.status === "recording"
+    ? `<div class="wb-diagnostic-value"><span>Timer</span><strong>${escapeHTML(formatTimer(state.elapsedMs))}</strong></div>`
+    : "";
+
+const renderError = (state: RecordingState): string =>
+  state.status === "error"
+    ? `<p class="wb-recording-error" role="alert">${escapeHTML(state.message)}</p>`
+    : "";
+
+export const renderRecordingControls = (state: RecordingState): string => `
+  <section id="wb-recording-panel" class="wb-recording-panel">
+    <h3>Recording</h3>
+    <div class="wb-recording-grid">
+      <div class="wb-diagnostic-value"><span>Status</span><strong>${escapeHTML(state.status)}</strong></div>
+      ${renderTimer(state)}
+    </div>
+    ${renderError(state)}
+    ${renderAction(state)}
+  </section>
+`;

--- a/src/features/diagnostic-workbench/renderRecordingControls.ts
+++ b/src/features/diagnostic-workbench/renderRecordingControls.ts
@@ -1,7 +1,7 @@
 import { escapeHTML } from "../../shared/browser/escapeHTML";
 import type { RecordingState } from "./recording/sessionRecorder";
 
-const formatTimer = (elapsedMs: number): string => {
+export const formatRecordingTimer = (elapsedMs: number): string => {
   const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
@@ -13,6 +13,8 @@ const renderAction = (state: RecordingState): string => {
   switch (state.status) {
     case "recording":
       return `<button class="wb-btn wb-recording-stop" data-wb-action="stopRecording">Stop</button>`;
+    case "starting":
+      return `<button class="wb-btn wb-btn-secondary" disabled>Preparing</button>`;
     case "saving":
       return `<button class="wb-btn wb-btn-secondary" disabled>Saving</button>`;
     case "idle":
@@ -23,7 +25,7 @@ const renderAction = (state: RecordingState): string => {
 
 const renderTimer = (state: RecordingState): string =>
   state.status === "recording"
-    ? `<div class="wb-diagnostic-value"><span>Timer</span><strong>${escapeHTML(formatTimer(state.elapsedMs))}</strong></div>`
+    ? `<div class="wb-diagnostic-value"><span>Timer</span><strong data-recording-timer>${escapeHTML(formatRecordingTimer(state.elapsedMs))}</strong></div>`
     : "";
 
 const renderError = (state: RecordingState): string =>

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -37,6 +37,8 @@ import { renderSideTriggerCalibrationControls } from "./renderSideTriggerCalibra
 import { renderSideTriggerPanel } from "./renderSideTriggerPanel";
 import { renderSideWorldLandmarks } from "./renderWorldLandmarks";
 import { renderTuningControls } from "./renderTuningControls";
+import { renderRecordingControls } from "./renderRecordingControls";
+import type { RecordingState } from "./recording/sessionRecorder";
 
 export interface WorkbenchInspectionState {
   readonly frontDetection: FrontHandDetection | undefined;
@@ -163,6 +165,8 @@ const defaultInspectionState: WorkbenchInspectionState = {
   fusionTuning: defaultFusionTuning
 };
 
+const defaultRecordingState: RecordingState = { status: "idle" };
+
 const renderInspectionPane = (
   lanePrefix: "front" | "side",
   kind: "raw" | "filtered"
@@ -224,11 +228,13 @@ const renderInspectionLane = (
 
 const renderPreviewing = (
   state: WorkbenchState,
-  inspection: WorkbenchInspectionState
+  inspection: WorkbenchInspectionState,
+  recording: RecordingState
 ): string => `
   <div class="wb-previewing">
     <h2>ライブプレビュー</h2>
     ${renderInlineError(state.error)}
+    ${renderRecordingControls(recording)}
     <div class="wb-preview-grid">
       ${renderInspectionLane(
         "front",
@@ -268,7 +274,8 @@ const renderPreviewing = (
 
 export const renderWorkbenchHTML = (
   state: WorkbenchState,
-  inspection: WorkbenchInspectionState = defaultInspectionState
+  inspection: WorkbenchInspectionState = defaultInspectionState,
+  recording: RecordingState = defaultRecordingState
 ): string => {
   switch (state.screen) {
     case "permission":
@@ -286,6 +293,6 @@ export const renderWorkbenchHTML = (
     case "deviceSelection":
       return renderDeviceSelection(state);
     case "previewing":
-      return renderPreviewing(state, inspection);
+      return renderPreviewing(state, inspection, recording);
   }
 };

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -115,6 +115,8 @@ const renderDeviceSelection = (state: WorkbenchState): string => `
 const defaultInspectionState: WorkbenchInspectionState = {
   frontDetection: undefined,
   sideDetection: undefined,
+  frontFrameTimestamp: undefined,
+  sideFrameTimestamp: undefined,
   frontLaneHealth: "notStarted",
   sideLaneHealth: "notStarted",
   frontAimFrame: undefined,

--- a/src/features/diagnostic-workbench/renderWorkbench.ts
+++ b/src/features/diagnostic-workbench/renderWorkbench.ts
@@ -4,29 +4,11 @@ import type {
   FrameTimestamp,
   LaneHealthStatus
 } from "../../shared/types/camera";
-import type {
-  FusedGameInputFrame,
-  FusionTelemetry
-} from "../../shared/types/fusion";
-import type { AimInputFrame, FrontAimTelemetry } from "../../shared/types/aim";
-import type {
-  FrontHandDetection,
-  SideHandDetection
-} from "../../shared/types/hand";
-import type {
-  SideTriggerTelemetry,
-  TriggerInputFrame
-} from "../../shared/types/trigger";
-import { defaultFusionTuning, type FusionTuning } from "../input-fusion";
-import {
-  defaultFrontAimCalibration,
-  type FrontAimCalibration
-} from "../front-aim";
+import { defaultFusionTuning } from "../input-fusion";
+import { defaultFrontAimCalibration } from "../front-aim";
 import {
   defaultSideTriggerCalibration,
-  defaultSideTriggerTuning,
-  type SideTriggerCalibration,
-  type SideTriggerTuning
+  defaultSideTriggerTuning
 } from "../side-trigger";
 import { formatFrameTimestamp } from "./timestampFormat";
 import { renderFrontAimCalibrationControls } from "./renderFrontAimCalibrationControls";
@@ -39,25 +21,7 @@ import { renderSideWorldLandmarks } from "./renderWorldLandmarks";
 import { renderTuningControls } from "./renderTuningControls";
 import { renderRecordingControls } from "./renderRecordingControls";
 import type { RecordingState } from "./recording/sessionRecorder";
-
-export interface WorkbenchInspectionState {
-  readonly frontDetection: FrontHandDetection | undefined;
-  readonly sideDetection: SideHandDetection | undefined;
-  readonly frontFrameTimestamp?: FrameTimestamp;
-  readonly sideFrameTimestamp?: FrameTimestamp;
-  readonly frontLaneHealth: LaneHealthStatus;
-  readonly sideLaneHealth: LaneHealthStatus;
-  readonly frontAimFrame: AimInputFrame | undefined;
-  readonly frontAimTelemetry: FrontAimTelemetry | undefined;
-  readonly frontAimCalibration: FrontAimCalibration;
-  readonly sideTriggerFrame: TriggerInputFrame | undefined;
-  readonly sideTriggerTelemetry: SideTriggerTelemetry | undefined;
-  readonly sideTriggerCalibration: SideTriggerCalibration;
-  readonly sideTriggerTuning: SideTriggerTuning;
-  readonly fusionFrame: FusedGameInputFrame | undefined;
-  readonly fusionTelemetry: FusionTelemetry | undefined;
-  readonly fusionTuning: FusionTuning;
-}
+import type { WorkbenchInspectionState } from "./workbenchInspectionState";
 
 const renderPermissionScreen = (): string => `
   <div class="wb-screen">

--- a/src/features/diagnostic-workbench/workbenchInspectionState.ts
+++ b/src/features/diagnostic-workbench/workbenchInspectionState.ts
@@ -25,8 +25,8 @@ import type {
 export interface WorkbenchInspectionState {
   readonly frontDetection: FrontHandDetection | undefined;
   readonly sideDetection: SideHandDetection | undefined;
-  readonly frontFrameTimestamp?: FrameTimestamp;
-  readonly sideFrameTimestamp?: FrameTimestamp;
+  readonly frontFrameTimestamp: FrameTimestamp | undefined;
+  readonly sideFrameTimestamp: FrameTimestamp | undefined;
   readonly frontLaneHealth: LaneHealthStatus;
   readonly sideLaneHealth: LaneHealthStatus;
   readonly frontAimFrame: AimInputFrame | undefined;

--- a/src/features/diagnostic-workbench/workbenchInspectionState.ts
+++ b/src/features/diagnostic-workbench/workbenchInspectionState.ts
@@ -1,0 +1,42 @@
+import type { AimInputFrame, FrontAimTelemetry } from "../../shared/types/aim";
+import type {
+  FrameTimestamp,
+  LaneHealthStatus
+} from "../../shared/types/camera";
+import type {
+  FusedGameInputFrame,
+  FusionTelemetry
+} from "../../shared/types/fusion";
+import type {
+  FrontHandDetection,
+  SideHandDetection
+} from "../../shared/types/hand";
+import type {
+  SideTriggerTelemetry,
+  TriggerInputFrame
+} from "../../shared/types/trigger";
+import type { FusionTuning } from "../input-fusion";
+import type { FrontAimCalibration } from "../front-aim";
+import type {
+  SideTriggerCalibration,
+  SideTriggerTuning
+} from "../side-trigger";
+
+export interface WorkbenchInspectionState {
+  readonly frontDetection: FrontHandDetection | undefined;
+  readonly sideDetection: SideHandDetection | undefined;
+  readonly frontFrameTimestamp?: FrameTimestamp;
+  readonly sideFrameTimestamp?: FrameTimestamp;
+  readonly frontLaneHealth: LaneHealthStatus;
+  readonly sideLaneHealth: LaneHealthStatus;
+  readonly frontAimFrame: AimInputFrame | undefined;
+  readonly frontAimTelemetry: FrontAimTelemetry | undefined;
+  readonly frontAimCalibration: FrontAimCalibration;
+  readonly sideTriggerFrame: TriggerInputFrame | undefined;
+  readonly sideTriggerTelemetry: SideTriggerTelemetry | undefined;
+  readonly sideTriggerCalibration: SideTriggerCalibration;
+  readonly sideTriggerTuning: SideTriggerTuning;
+  readonly fusionFrame: FusedGameInputFrame | undefined;
+  readonly fusionTelemetry: FusionTelemetry | undefined;
+  readonly fusionTuning: FusionTuning;
+}

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -268,6 +268,26 @@ h4 {
   overflow-wrap: anywhere;
 }
 
+.wb-recording-stop {
+  border-color: #c0392b;
+  background: #c0392b;
+  color: #fff;
+  padding: 0.65rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.wb-recording-stop:hover {
+  border-color: #922b21;
+  background: #922b21;
+}
+
+.wb-recording-stop:focus-visible {
+  outline: 3px solid #ffb4a8;
+  outline-offset: 2px;
+}
+
 .wb-controls {
   margin-top: 1rem;
 }

--- a/src/styles/diagnostic.css
+++ b/src/styles/diagnostic.css
@@ -182,6 +182,7 @@ h4 {
 .wb-aim-panel,
 .wb-trigger-panel,
 .wb-fusion-panel,
+.wb-recording-panel,
 .wb-tuning-panel {
   margin-top: 0.75rem;
   border: 1px solid #31425f;
@@ -213,6 +214,7 @@ h4 {
 .wb-aim-grid,
 .wb-trigger-grid,
 .wb-fusion-grid,
+.wb-recording-grid,
 .wb-tuning-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -260,6 +262,12 @@ h4 {
   text-align: center;
 }
 
+.wb-recording-error {
+  margin-top: 0.5rem;
+  color: #ffb4a8;
+  overflow-wrap: anywhere;
+}
+
 .wb-controls {
   margin-top: 1rem;
 }
@@ -279,6 +287,7 @@ h4 {
   .wb-aim-grid,
   .wb-trigger-grid,
   .wb-fusion-grid,
+  .wb-recording-grid,
   .wb-tuning-grid {
     grid-template-columns: 1fr;
   }

--- a/tests/e2e/diagnostic.smoke.spec.ts
+++ b/tests/e2e/diagnostic.smoke.spec.ts
@@ -66,6 +66,60 @@ const installFakeCameras = async (
   );
 };
 
+const installFakeRecording = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    class FakeMediaRecorder {
+      static isTypeSupported(): boolean {
+        return true;
+      }
+
+      ondataavailable: ((event: BlobEvent) => void) | null = null;
+      onstop: ((event: Event) => void) | null = null;
+      state: RecordingState = "inactive";
+
+      start(): void {
+        this.state = "recording";
+      }
+
+      stop(): void {
+        this.state = "inactive";
+        this.onstop?.(new Event("stop"));
+      }
+    }
+
+    const createWritable = () => ({
+      write: () => Promise.resolve(),
+      close: () => Promise.resolve()
+    });
+    const directoryHandle = {
+      queryPermission: () => Promise.resolve("granted" as PermissionState),
+      requestPermission: () => Promise.resolve("granted" as PermissionState),
+      getFileHandle: (name: string) =>
+        Promise.resolve({
+          kind: "file" as const,
+          name,
+          createWritable
+        }),
+      deleteEntry: () => Promise.resolve(),
+      async *entries() {
+        await Promise.resolve();
+        for (const entry of [] as [string, FileSystemFileHandle][]) {
+          yield entry;
+        }
+      }
+    };
+
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: FakeMediaRecorder
+    });
+    Object.defineProperty(window, "showDirectoryPicker", {
+      configurable: true,
+      value: () => Promise.resolve(directoryHandle)
+    });
+  });
+};
+
 test("diagnostic workbench runs permission, device selection, previews, swap, and reselect", async ({
   page
 }) => {
@@ -198,4 +252,41 @@ test("diagnostic workbench warns when only one camera is available", async ({
       "1台のカメラをフロントとサイドの両方に再利用することはできません"
     )
   ).toBeVisible();
+});
+
+test("diagnostic recording timer tick preserves focused slider edits", async ({
+  page
+}) => {
+  await page.clock.install({
+    time: new Date("2026-04-19T08:30:15.000Z")
+  });
+  await installFakeCameras(page, [
+    { deviceId: "front-device-id", label: "Front Camera" },
+    { deviceId: "side-device-id", label: "Side Camera" }
+  ]);
+  await installFakeRecording(page);
+
+  await page.goto("/diagnostic.html");
+  await page.getByRole("button", { name: "カメラ許可" }).click();
+  await page.locator("#wb-front-select").selectOption("front-device-id");
+  await page.locator("#wb-side-select").selectOption("side-device-id");
+  await page.getByRole("button", { name: "確定" }).click();
+  await page.getByRole("button", { name: "Record" }).click();
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  const slider = page.locator("[data-side-trigger-tuning='pullEnterThreshold']");
+  await slider.focus();
+  await slider.evaluate((element) => {
+    (element as HTMLInputElement).value = "0.73";
+  });
+
+  await page.clock.fastForward(2_000);
+
+  await expect(page.locator("[data-recording-timer]")).toHaveText("00:02");
+  await expect(slider).toHaveValue("0.73");
+  expect(
+    await page.evaluate(() =>
+      document.activeElement?.getAttribute("data-side-trigger-tuning")
+    )
+  ).toBe("pullEnterThreshold");
 });

--- a/tests/helpers/fileSystemAccessMocks.ts
+++ b/tests/helpers/fileSystemAccessMocks.ts
@@ -1,0 +1,95 @@
+class FakeFileSystemWritableFileStream {
+  readonly writes: unknown[] = [];
+  closed = false;
+
+  write(data: unknown): Promise<void> {
+    if (this.closed) {
+      throw new Error("Cannot write to a closed file stream");
+    }
+
+    this.writes.push(data);
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.closed = true;
+    return Promise.resolve();
+  }
+}
+
+export class FakeFileSystemFileHandle {
+  readonly kind = "file";
+  readonly name: string;
+  readonly writable = new FakeFileSystemWritableFileStream();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  createWritable(): Promise<FakeFileSystemWritableFileStream> {
+    return Promise.resolve(this.writable);
+  }
+
+  text(): Promise<string> {
+    return Promise.resolve(
+      this.writable.writes
+        .map((chunk) => (typeof chunk === "string" ? chunk : ""))
+        .join("")
+    );
+  }
+}
+
+export class FakeFileSystemDirectoryHandle {
+  readonly kind = "directory";
+  readonly name: string;
+  readonly files = new Map<string, FakeFileSystemFileHandle>();
+  readonly deletedNames: string[] = [];
+  permissionState: PermissionState = "granted";
+
+  constructor(name = "captures") {
+    this.name = name;
+  }
+
+  queryPermission(): Promise<PermissionState> {
+    return Promise.resolve(this.permissionState);
+  }
+
+  requestPermission(): Promise<PermissionState> {
+    return Promise.resolve(this.permissionState);
+  }
+
+  getFileHandle(
+    name: string,
+    options: FileSystemGetFileOptions = {}
+  ): Promise<FakeFileSystemFileHandle> {
+    const existing = this.files.get(name);
+
+    if (existing !== undefined) {
+      return Promise.resolve(existing);
+    }
+
+    if (options.create !== true) {
+      throw new Error(`Missing fake file handle: ${name}`);
+    }
+
+    const handle = new FakeFileSystemFileHandle(name);
+    this.files.set(name, handle);
+    return Promise.resolve(handle);
+  }
+
+  deleteEntry(name: string): Promise<void> {
+    this.files.delete(name);
+    this.deletedNames.push(name);
+    return Promise.resolve();
+  }
+
+  async *entries(): AsyncIterableIterator<
+    [string, FakeFileSystemFileHandle | FakeFileSystemDirectoryHandle]
+  > {
+    await Promise.resolve();
+
+    for (const entry of this.files.entries()) {
+      yield entry;
+    }
+  }
+}

--- a/tests/helpers/fileSystemAccessMocks.ts
+++ b/tests/helpers/fileSystemAccessMocks.ts
@@ -20,19 +20,25 @@ class FakeFileSystemWritableFileStream {
 export class FakeFileSystemFileHandle {
   readonly kind = "file";
   readonly name: string;
-  readonly writable = new FakeFileSystemWritableFileStream();
+  readonly writableStreams: FakeFileSystemWritableFileStream[] = [];
 
   constructor(name: string) {
     this.name = name;
   }
 
+  get latestWritable(): FakeFileSystemWritableFileStream | undefined {
+    return this.writableStreams[this.writableStreams.length - 1];
+  }
+
   createWritable(): Promise<FakeFileSystemWritableFileStream> {
-    return Promise.resolve(this.writable);
+    const writable = new FakeFileSystemWritableFileStream();
+    this.writableStreams.push(writable);
+    return Promise.resolve(writable);
   }
 
   text(): Promise<string> {
     return Promise.resolve(
-      this.writable.writes
+      (this.latestWritable?.writes ?? [])
         .map((chunk) => (typeof chunk === "string" ? chunk : ""))
         .join("")
     );

--- a/tests/integration/diagnosticRecording.test.ts
+++ b/tests/integration/diagnosticRecording.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSessionRecorder } from "../../src/features/diagnostic-workbench/recording/sessionRecorder";
 import type { TelemetryFrame } from "../../src/features/diagnostic-workbench/recording/telemetryFrame";
 import { defaultFrontAimCalibration } from "../../src/features/front-aim";
@@ -12,7 +12,9 @@ class IntegrationMediaRecorder {
   }
 
   ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
   state: RecordingState = "inactive";
+  private queuedStopText: string | undefined;
 
   constructor(readonly stream: MediaStream) {
     IntegrationMediaRecorder.instances.push(this);
@@ -24,10 +26,19 @@ class IntegrationMediaRecorder {
 
   stop(): void {
     this.state = "inactive";
+    if (this.queuedStopText !== undefined) {
+      this.emitBlob(this.queuedStopText);
+      this.queuedStopText = undefined;
+    }
+    this.onstop?.();
   }
 
   emitBlob(text: string): void {
     this.ondataavailable?.({ data: new Blob([text]) } as BlobEvent);
+  }
+
+  queueStopBlob(text: string): void {
+    this.queuedStopText = text;
   }
 }
 
@@ -99,9 +110,16 @@ const createTelemetryFrame = (): TelemetryFrame => {
 };
 
 describe("diagnostic recording integration", () => {
-  it("runs a record to stop flow with mocked File System Access handles", async () => {
+  beforeEach(() => {
     IntegrationMediaRecorder.instances.length = 0;
     vi.stubGlobal("MediaRecorder", IntegrationMediaRecorder);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("runs a record to stop flow with mocked File System Access handles", async () => {
     const directory = new FakeFileSystemDirectoryHandle();
     let emitFrame: ((frame: TelemetryFrame) => void) | undefined;
     const recorder = createSessionRecorder({
@@ -119,23 +137,27 @@ describe("diagnostic recording integration", () => {
         return vi.fn();
       }
     });
-    IntegrationMediaRecorder.instances[0]?.emitBlob("front-video");
-    IntegrationMediaRecorder.instances[1]?.emitBlob("side-video");
+    IntegrationMediaRecorder.instances[0]?.queueStopBlob("front-video");
+    IntegrationMediaRecorder.instances[1]?.queueStopBlob("side-video");
     emitFrame?.(createTelemetryFrame());
     await recorder.stop();
 
-    const jsonFile = directory.files.get("telemetry-2026-04-19T08-30-15Z.json");
+    const jsonFile = directory.files.get(
+      "telemetry-2026-04-19T08-30-15-000Z.json"
+    );
     if (jsonFile === undefined) {
       throw new Error("Telemetry JSON file was not written");
     }
 
-    expect(directory.files.get("front.webm")?.writable.writes).toHaveLength(1);
-    expect(directory.files.get("side.webm")?.writable.writes).toHaveLength(1);
+    expect(
+      directory.files.get("front.webm")?.latestWritable?.writes
+    ).toHaveLength(1);
+    expect(
+      directory.files.get("side.webm")?.latestWritable?.writes
+    ).toHaveLength(1);
     expect(JSON.parse(await jsonFile.text())).toMatchObject({
       schemaVersion: 1,
       frames: [{ fusionMode: "frontOnlyAim" }]
     });
-
-    vi.unstubAllGlobals();
   });
 });

--- a/tests/integration/diagnosticRecording.test.ts
+++ b/tests/integration/diagnosticRecording.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionRecorder } from "../../src/features/diagnostic-workbench/recording/sessionRecorder";
+import type { TelemetryFrame } from "../../src/features/diagnostic-workbench/recording/telemetryFrame";
+import { defaultFrontAimCalibration } from "../../src/features/front-aim";
+import { defaultSideTriggerCalibration } from "../../src/features/side-trigger";
+import { FakeFileSystemDirectoryHandle } from "../helpers/fileSystemAccessMocks";
+
+class IntegrationMediaRecorder {
+  static readonly instances: IntegrationMediaRecorder[] = [];
+  static isTypeSupported(): boolean {
+    return true;
+  }
+
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  state: RecordingState = "inactive";
+
+  constructor(readonly stream: MediaStream) {
+    IntegrationMediaRecorder.instances.push(this);
+  }
+
+  start(): void {
+    this.state = "recording";
+  }
+
+  stop(): void {
+    this.state = "inactive";
+  }
+
+  emitBlob(text: string): void {
+    this.ondataavailable?.({ data: new Blob([text]) } as BlobEvent);
+  }
+}
+
+const createTelemetryFrame = (): TelemetryFrame => {
+  const timestamp = {
+    frameTimestampMs: 123,
+    timestampSource: "requestVideoFrameCallbackCaptureTime" as const,
+    presentedFrames: 3,
+    receivedAtPerformanceMs: 124
+  };
+
+  return {
+    timestamp,
+    fusionMode: "frontOnlyAim",
+    calibration: {
+      frontAim: defaultFrontAimCalibration,
+      sideTrigger: defaultSideTriggerCalibration
+    },
+    front: {
+      landmarks: undefined,
+      laneHealth: "tracking",
+      aimContext: undefined
+    },
+    side: {
+      landmarks: undefined,
+      worldLandmarks: undefined,
+      sideViewQuality: "lost",
+      evidence: {
+        sideHandDetected: false,
+        sideViewQuality: "lost",
+        pullEvidenceScalar: 0,
+        releaseEvidenceScalar: 0,
+        triggerPostureConfidence: 0,
+        shotCandidateConfidence: 0,
+        rejectReason: "handNotDetected",
+        usedWorldLandmarks: false
+      },
+      fsmPhase: "SideTriggerNoHand",
+      triggerEdge: undefined,
+      laneHealth: "captureLost"
+    },
+    fusion: {
+      fusionTimestampMs: 123,
+      fusionMode: "frontOnlyAim",
+      timeDeltaBetweenLanesMs: undefined,
+      aim: undefined,
+      trigger: undefined,
+      shotFired: false,
+      inputConfidence: 0.4,
+      frontSource: {
+        laneRole: "frontAim",
+        frameTimestamp: timestamp,
+        frameAgeMs: 0,
+        laneHealth: "tracking",
+        availability: "available",
+        rejectReason: "none"
+      },
+      sideSource: {
+        laneRole: "sideTrigger",
+        frameTimestamp: undefined,
+        frameAgeMs: undefined,
+        laneHealth: "captureLost",
+        availability: "unavailable",
+        rejectReason: "laneFailed"
+      },
+      fusionRejectReason: "none"
+    }
+  };
+};
+
+describe("diagnostic recording integration", () => {
+  it("runs a record to stop flow with mocked File System Access handles", async () => {
+    IntegrationMediaRecorder.instances.length = 0;
+    vi.stubGlobal("MediaRecorder", IntegrationMediaRecorder);
+    const directory = new FakeFileSystemDirectoryHandle();
+    let emitFrame: ((frame: TelemetryFrame) => void) | undefined;
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now: () => new Date("2026-04-19T08:30:15.000Z")
+    });
+
+    await recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: (callback) => {
+        emitFrame = callback;
+        return vi.fn();
+      }
+    });
+    IntegrationMediaRecorder.instances[0]?.emitBlob("front-video");
+    IntegrationMediaRecorder.instances[1]?.emitBlob("side-video");
+    emitFrame?.(createTelemetryFrame());
+    await recorder.stop();
+
+    const jsonFile = directory.files.get("telemetry-2026-04-19T08-30-15Z.json");
+    if (jsonFile === undefined) {
+      throw new Error("Telemetry JSON file was not written");
+    }
+
+    expect(directory.files.get("front.webm")?.writable.writes).toHaveLength(1);
+    expect(directory.files.get("side.webm")?.writable.writes).toHaveLength(1);
+    expect(JSON.parse(await jsonFile.text())).toMatchObject({
+      schemaVersion: 1,
+      frames: [{ fusionMode: "frontOnlyAim" }]
+    });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/integration/importBoundaries.test.ts
+++ b/tests/integration/importBoundaries.test.ts
@@ -169,7 +169,6 @@ describe("M5 import boundaries", () => {
     const mainImports = importsFrom(join(rootDir, "src/main.ts"));
 
     expect(indexHtml).not.toContain("diagnostic-workbench/recording");
-    expect(indexHtml).not.toContain("recording/");
     expect(mainImports.join("\n")).not.toContain(
       "diagnostic-workbench/recording"
     );

--- a/tests/integration/importBoundaries.test.ts
+++ b/tests/integration/importBoundaries.test.ts
@@ -164,6 +164,17 @@ describe("M5 import boundaries", () => {
     expect(imports.join("\n")).not.toContain("diagnostic-workbench");
   });
 
+  it("keeps the game page and entry out of diagnostic recording modules", () => {
+    const indexHtml = readFileSync(join(rootDir, "index.html"), "utf8");
+    const mainImports = importsFrom(join(rootDir, "src/main.ts"));
+
+    expect(indexHtml).not.toContain("diagnostic-workbench/recording");
+    expect(indexHtml).not.toContain("recording/");
+    expect(mainImports.join("\n")).not.toContain(
+      "diagnostic-workbench/recording"
+    );
+  });
+
   it("keeps app files out of diagnostic workbench modules", () => {
     const appFiles = listSourceFiles(join(rootDir, "src/app"));
     const forbidden = ["diagnostic-workbench"];

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -3,15 +3,31 @@ import type { WorkbenchState } from "../../src/features/diagnostic-workbench/Dia
 
 const {
   deviceChangeObserverStop,
+  intervalState,
   listeners,
   liveInspectionMock,
   observeDeviceChangeMock,
+  recorderListenerState,
   recorderMock,
+  renderWorkbenchHTMLMock,
   workbenchMock
 } = vi.hoisted(() => {
   const listeners = new Map<string, EventListener>();
+  const recorderListenerState: {
+    current: ((state: unknown) => void) | undefined;
+  } = { current: undefined };
+  const intervalState: { current: (() => void) | undefined } = {
+    current: undefined
+  };
   const deviceChangeObserverStop = vi.fn();
   const observeDeviceChangeMock = vi.fn();
+  const renderWorkbenchHTMLMock = vi.fn<
+    (
+      state: unknown,
+      inspection: unknown,
+      recording: { status: string; elapsedMs?: number }
+    ) => string
+  >(() => "");
   const liveInspectionMock = {
     getState: vi.fn<() => unknown>(() => ({
       frontDetection: undefined,
@@ -58,8 +74,13 @@ const {
     destroy: vi.fn()
   };
   const recorderMock = {
-    getState: vi.fn(() => ({ status: "idle" })),
-    subscribe: vi.fn(),
+    getState: vi.fn<() => { status: string; elapsedMs?: number }>(() => ({
+      status: "idle"
+    })),
+    subscribe: vi.fn((listener: (state: unknown) => void) => {
+      recorderListenerState.current = listener;
+      return vi.fn();
+    }),
     start: vi.fn<(options: unknown) => Promise<void>>(() => Promise.resolve()),
     stop: vi.fn(() => Promise.resolve()),
     isRecording: vi.fn(() => false),
@@ -86,10 +107,13 @@ const {
 
   return {
     deviceChangeObserverStop,
+    intervalState,
     listeners,
     liveInspectionMock,
     observeDeviceChangeMock,
+    recorderListenerState,
     recorderMock,
+    renderWorkbenchHTMLMock,
     workbenchMock
   };
 });
@@ -99,7 +123,7 @@ vi.mock("../../src/features/diagnostic-workbench/DiagnosticWorkbench", () => ({
 }));
 
 vi.mock("../../src/features/diagnostic-workbench/renderWorkbench", () => ({
-  renderWorkbenchHTML: vi.fn(() => "")
+  renderWorkbenchHTML: renderWorkbenchHTMLMock
 }));
 
 vi.mock("../../src/features/camera/observeDeviceChange", () => ({
@@ -144,31 +168,89 @@ class FakeHTMLElement {
   }
 }
 
+class FakeRoot {
+  private html = "";
+
+  get innerHTML(): string {
+    return this.html;
+  }
+
+  set innerHTML(value: string) {
+    this.html = value;
+    rebuildRenderedElements(value);
+  }
+
+  addEventListener = vi.fn((type: string, listener: EventListener) => {
+    listeners.set(type, listener);
+  });
+}
+
+interface FakeRenderedElement {
+  textContent: string;
+  value?: string;
+}
+
+let root: FakeRoot;
+let timerElement: FakeRenderedElement | undefined;
+let focusedSlider: FakeRenderedElement | undefined;
+let activeElement: FakeRenderedElement | undefined;
+
+const rebuildRenderedElements = (html: string): void => {
+  if (activeElement === focusedSlider) {
+    activeElement = undefined;
+  }
+
+  timerElement = html.includes("data-recording-timer")
+    ? { textContent: "00:00" }
+    : undefined;
+  focusedSlider = html.includes("data-side-trigger-tuning")
+    ? { textContent: "", value: "0.5" }
+    : undefined;
+};
+
 describe("diagnostic main input handling", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    renderWorkbenchHTMLMock.mockImplementation(
+      (_state: unknown, _inspection: unknown, recording: { status: string }) =>
+        recording.status === "recording"
+          ? '<input value="0.5" data-side-trigger-tuning="pullEvidenceThreshold"><strong data-recording-timer>00:00</strong>'
+          : ""
+    );
     observeDeviceChangeMock.mockImplementation((callback: () => void) => {
       listeners.set("devicechange", callback as EventListener);
       return { stop: deviceChangeObserverStop };
     });
     listeners.clear();
-    const root = {
-      innerHTML: "",
-      addEventListener: vi.fn((type: string, listener: EventListener) => {
-        listeners.set(type, listener);
-      })
-    };
+    recorderListenerState.current = undefined;
+    intervalState.current = undefined;
+    timerElement = undefined;
+    focusedSlider = undefined;
+    activeElement = undefined;
+    root = new FakeRoot();
 
     vi.stubGlobal("HTMLInputElement", FakeHTMLInputElement);
     vi.stubGlobal("HTMLElement", FakeHTMLElement);
     vi.stubGlobal("document", {
       querySelector: vi.fn((selector: string) =>
-        selector === "#diagnostic-app" ? root : null
-      )
+        selector === "#diagnostic-app"
+          ? root
+          : selector === "[data-recording-timer]"
+            ? (timerElement ?? null)
+            : null
+      ),
+      get activeElement() {
+        return activeElement ?? null;
+      }
     });
     vi.stubGlobal("window", {
-      addEventListener: vi.fn()
+      addEventListener: vi.fn(),
+      setInterval: vi.fn((callback: () => void) => {
+        intervalState.current = callback;
+        return 1;
+      }),
+      clearInterval: vi.fn()
     });
 
     await import("../../src/diagnostic-main");
@@ -347,5 +429,31 @@ describe("diagnostic main input handling", () => {
     await vi.waitFor(() => {
       expect(recorderMock.stop).toHaveBeenCalledOnce();
     });
+  });
+
+  it("updates recording timer ticks without rebuilding the focused slider", () => {
+    recorderMock.getState.mockReturnValue({
+      status: "recording",
+      elapsedMs: 0
+    });
+
+    recorderListenerState.current?.({ status: "recording", elapsedMs: 0 });
+
+    if (focusedSlider === undefined) {
+      throw new Error("recording render did not create the tuning slider");
+    }
+    const sliderBeforeTick = focusedSlider;
+    sliderBeforeTick.value = "0.8";
+    activeElement = sliderBeforeTick;
+
+    recorderMock.getState.mockReturnValue({
+      status: "recording",
+      elapsedMs: 2_000
+    });
+    intervalState.current?.();
+
+    expect(activeElement).toBe(sliderBeforeTick);
+    expect(sliderBeforeTick.value).toBe("0.8");
+    expect(timerElement?.textContent).toBe("00:02");
   });
 });

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkbenchState } from "../../src/features/diagnostic-workbench/DiagnosticWorkbench";
 
 const {
   deviceChangeObserverStop,
   listeners,
   liveInspectionMock,
   observeDeviceChangeMock,
+  recorderMock,
   workbenchMock
 } = vi.hoisted(() => {
   const listeners = new Map<string, EventListener>();
   const deviceChangeObserverStop = vi.fn();
   const observeDeviceChangeMock = vi.fn();
   const liveInspectionMock = {
-    getState: vi.fn(() => ({
+    getState: vi.fn<() => unknown>(() => ({
       frontDetection: undefined,
       sideDetection: undefined,
       frontLaneHealth: "notStarted",
@@ -51,11 +53,20 @@ const {
     resetSideTriggerTuning: vi.fn(),
     setFusionTuning: vi.fn(),
     resetFusionTuning: vi.fn(),
+    subscribeFrame: vi.fn(),
     updateDom: vi.fn(),
     destroy: vi.fn()
   };
+  const recorderMock = {
+    getState: vi.fn(() => ({ status: "idle" })),
+    subscribe: vi.fn(),
+    start: vi.fn<(options: unknown) => Promise<void>>(() => Promise.resolve()),
+    stop: vi.fn(() => Promise.resolve()),
+    isRecording: vi.fn(() => false),
+    destroy: vi.fn()
+  };
   const workbenchMock = {
-    getState: vi.fn(() => ({
+    getState: vi.fn<() => WorkbenchState>(() => ({
       screen: "permission",
       devices: [],
       frontAssignment: undefined,
@@ -78,6 +89,7 @@ const {
     listeners,
     liveInspectionMock,
     observeDeviceChangeMock,
+    recorderMock,
     workbenchMock
   };
 });
@@ -101,6 +113,13 @@ vi.mock(
   })
 );
 
+vi.mock(
+  "../../src/features/diagnostic-workbench/recording/sessionRecorder",
+  () => ({
+    createSessionRecorder: vi.fn(() => recorderMock)
+  })
+);
+
 class FakeHTMLInputElement {
   readonly dataset: Record<string, string>;
   readonly valueAsNumber: number;
@@ -108,6 +127,20 @@ class FakeHTMLInputElement {
   constructor(dataset: Record<string, string>, valueAsNumber: number) {
     this.dataset = dataset;
     this.valueAsNumber = valueAsNumber;
+  }
+}
+
+class FakeHTMLElement {
+  readonly dataset: Record<string, string>;
+  private readonly actionEl: unknown;
+
+  constructor(dataset: Record<string, string>, actionEl?: unknown) {
+    this.dataset = dataset;
+    this.actionEl = actionEl ?? this;
+  }
+
+  closest(): unknown {
+    return this.actionEl;
   }
 }
 
@@ -128,6 +161,7 @@ describe("diagnostic main input handling", () => {
     };
 
     vi.stubGlobal("HTMLInputElement", FakeHTMLInputElement);
+    vi.stubGlobal("HTMLElement", FakeHTMLElement);
     vi.stubGlobal("document", {
       querySelector: vi.fn((selector: string) =>
         selector === "#diagnostic-app" ? root : null
@@ -181,6 +215,75 @@ describe("diagnostic main input handling", () => {
       expect(
         workbenchMock.refreshDevicesFromDeviceChange
       ).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("starts diagnostic recording from the recording controls", async () => {
+    const clickListener = listeners.get("click");
+
+    if (clickListener === undefined) {
+      throw new Error("diagnostic click listener was not registered");
+    }
+
+    const frontStream = { id: "front-stream" } as MediaStream;
+    const sideStream = { id: "side-stream" } as MediaStream;
+    workbenchMock.getState.mockReturnValue({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: { stream: frontStream, deviceId: "front", stop: vi.fn() },
+      sideStream: { stream: sideStream, deviceId: "side", stop: vi.fn() },
+      error: undefined
+    });
+
+    const actionEl = new FakeHTMLElement({
+      wbAction: "startRecording"
+    });
+    const target = new FakeHTMLElement({}, actionEl);
+
+    clickListener({
+      target
+    } as unknown as MouseEvent);
+
+    await vi.waitFor(() => {
+      expect(recorderMock.start).toHaveBeenCalledOnce();
+    });
+    const startOptions = recorderMock.start.mock.calls[0]?.[0];
+
+    if (startOptions === undefined) {
+      throw new Error("recorder.start was not called with options");
+    }
+
+    const options = startOptions as {
+      readonly frontStream: MediaStream;
+      readonly sideStream: MediaStream;
+      readonly subscribeFrame: unknown;
+    };
+
+    expect(options.frontStream).toBe(frontStream);
+    expect(options.sideStream).toBe(sideStream);
+    expect(typeof options.subscribeFrame).toBe("function");
+  });
+
+  it("stops diagnostic recording from the recording controls", async () => {
+    const clickListener = listeners.get("click");
+
+    if (clickListener === undefined) {
+      throw new Error("diagnostic click listener was not registered");
+    }
+
+    const actionEl = new FakeHTMLElement({
+      wbAction: "stopRecording"
+    });
+    const target = new FakeHTMLElement({}, actionEl);
+
+    clickListener({
+      target
+    } as unknown as MouseEvent);
+
+    await vi.waitFor(() => {
+      expect(recorderMock.stop).toHaveBeenCalledOnce();
     });
   });
 });

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -266,6 +266,68 @@ describe("diagnostic main input handling", () => {
     expect(typeof options.subscribeFrame).toBe("function");
   });
 
+  it("does not start diagnostic recording outside previewing", () => {
+    const clickListener = listeners.get("click");
+
+    if (clickListener === undefined) {
+      throw new Error("diagnostic click listener was not registered");
+    }
+
+    workbenchMock.getState.mockReturnValue({
+      screen: "permission",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: undefined,
+      sideStream: undefined,
+      error: undefined
+    });
+
+    const actionEl = new FakeHTMLElement({
+      wbAction: "startRecording"
+    });
+    const target = new FakeHTMLElement({}, actionEl);
+
+    clickListener({
+      target
+    } as unknown as MouseEvent);
+
+    expect(recorderMock.start).not.toHaveBeenCalled();
+  });
+
+  it("does not start diagnostic recording without a front stream", () => {
+    const clickListener = listeners.get("click");
+
+    if (clickListener === undefined) {
+      throw new Error("diagnostic click listener was not registered");
+    }
+
+    workbenchMock.getState.mockReturnValue({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: undefined,
+      sideStream: {
+        stream: { id: "side-stream" } as MediaStream,
+        deviceId: "side",
+        stop: vi.fn()
+      },
+      error: undefined
+    });
+
+    const actionEl = new FakeHTMLElement({
+      wbAction: "startRecording"
+    });
+    const target = new FakeHTMLElement({}, actionEl);
+
+    clickListener({
+      target
+    } as unknown as MouseEvent);
+
+    expect(recorderMock.start).not.toHaveBeenCalled();
+  });
+
   it("stops diagnostic recording from the recording controls", async () => {
     const clickListener = listeners.get("click");
 

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -473,12 +473,53 @@ describe("diagnostic main input handling", () => {
 
     pagehideListener({ persisted: false } as PageTransitionEvent);
 
-    expect(listeners.has("window:beforeunload")).toBe(false);
+    expect(listeners.has("window:beforeunload")).toBe(true);
     expect(deviceChangeObserverStop).toHaveBeenCalledOnce();
     expect(window.clearInterval).toHaveBeenCalledWith(1);
     expect(recorderMock.destroy).toHaveBeenCalledOnce();
     expect(liveInspectionMock.destroy).toHaveBeenCalledOnce();
     expect(workbenchMock.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("warns before unload while recording is active", () => {
+    const beforeUnloadListener = listeners.get("window:beforeunload");
+
+    if (beforeUnloadListener === undefined) {
+      throw new Error("beforeunload listener was not registered");
+    }
+
+    recorderMock.getState.mockReturnValue({
+      status: "recording",
+      elapsedMs: 0
+    });
+    const event = {
+      preventDefault: vi.fn(),
+      returnValue: undefined
+    };
+
+    beforeUnloadListener(event as unknown as BeforeUnloadEvent);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.returnValue).toBe("");
+  });
+
+  it("does not warn before unload while recorder is idle", () => {
+    const beforeUnloadListener = listeners.get("window:beforeunload");
+
+    if (beforeUnloadListener === undefined) {
+      throw new Error("beforeunload listener was not registered");
+    }
+
+    recorderMock.getState.mockReturnValue({ status: "idle" });
+    const event = {
+      preventDefault: vi.fn(),
+      returnValue: undefined
+    };
+
+    beforeUnloadListener(event as unknown as BeforeUnloadEvent);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.returnValue).toBeUndefined();
   });
 
   it("keeps recorder state intact for BFCache pagehide", () => {

--- a/tests/unit/diagnostic-main.test.ts
+++ b/tests/unit/diagnostic-main.test.ts
@@ -245,7 +245,9 @@ describe("diagnostic main input handling", () => {
       }
     });
     vi.stubGlobal("window", {
-      addEventListener: vi.fn(),
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        listeners.set(`window:${type}`, listener);
+      }),
       setInterval: vi.fn((callback: () => void) => {
         intervalState.current = callback;
         return 1;
@@ -455,5 +457,42 @@ describe("diagnostic main input handling", () => {
     expect(activeElement).toBe(sliderBeforeTick);
     expect(sliderBeforeTick.value).toBe("0.8");
     expect(timerElement?.textContent).toBe("00:02");
+  });
+
+  it("uses pagehide for async recorder cleanup", () => {
+    recorderMock.getState.mockReturnValue({
+      status: "recording",
+      elapsedMs: 0
+    });
+    recorderListenerState.current?.({ status: "recording", elapsedMs: 0 });
+    const pagehideListener = listeners.get("window:pagehide");
+
+    if (pagehideListener === undefined) {
+      throw new Error("pagehide listener was not registered");
+    }
+
+    pagehideListener({ persisted: false } as PageTransitionEvent);
+
+    expect(listeners.has("window:beforeunload")).toBe(false);
+    expect(deviceChangeObserverStop).toHaveBeenCalledOnce();
+    expect(window.clearInterval).toHaveBeenCalledWith(1);
+    expect(recorderMock.destroy).toHaveBeenCalledOnce();
+    expect(liveInspectionMock.destroy).toHaveBeenCalledOnce();
+    expect(workbenchMock.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("keeps recorder state intact for BFCache pagehide", () => {
+    const pagehideListener = listeners.get("window:pagehide");
+
+    if (pagehideListener === undefined) {
+      throw new Error("pagehide listener was not registered");
+    }
+
+    pagehideListener({ persisted: true } as PageTransitionEvent);
+
+    expect(deviceChangeObserverStop).not.toHaveBeenCalled();
+    expect(recorderMock.destroy).not.toHaveBeenCalled();
+    expect(liveInspectionMock.destroy).not.toHaveBeenCalled();
+    expect(workbenchMock.destroy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
+++ b/tests/unit/features/diagnostic-workbench/liveLandmarkInspection.test.ts
@@ -1131,6 +1131,61 @@ describe("createLiveLandmarkInspection", () => {
     });
   });
 
+  it("keeps lane tracking and notifies later subscribers when a telemetry subscriber throws", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const frontTracker = createFakeTracker();
+    const sideTracker = createFakeTracker();
+    frontTracker.detect.mockResolvedValueOnce(createHandDetection());
+    sideTracker.detect.mockResolvedValueOnce(
+      createHandDetectionWithWorld(openWorldLandmarks())
+    );
+    createMediaPipeHandTrackerMock
+      .mockResolvedValueOnce(frontTracker)
+      .mockResolvedValueOnce(sideTracker);
+    const liveInspection = createLiveLandmarkInspection();
+    const videos = installPreviewVideos();
+    const throwingSubscriber = vi.fn(() => {
+      throw new Error("subscriber failed");
+    });
+    const laterSubscriber = vi.fn();
+
+    liveInspection.sync({
+      screen: "previewing",
+      devices: [],
+      frontAssignment: undefined,
+      sideAssignment: undefined,
+      frontStream: createPinnedStream("front-id"),
+      sideStream: createPinnedStream("side-id"),
+      error: undefined
+    });
+    videos.frontVideo.fireFrame({ captureTime: 100, presentedFrames: 1 });
+    await vi.waitFor(() => {
+      expect(liveInspection.getState().frontAimFrame).toBeDefined();
+    });
+
+    liveInspection.subscribeFrame(throwingSubscriber);
+    liveInspection.subscribeFrame(laterSubscriber);
+    videos.sideVideo.fireFrame({ captureTime: 112, presentedFrames: 1 });
+
+    await vi.waitFor(() => {
+      expect(laterSubscriber).toHaveBeenCalledOnce();
+    });
+    expect(liveInspection.getState().sideLaneHealth).toBe("tracking");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Diagnostic telemetry subscriber failed",
+      expect.objectContaining({
+        subscriberIndex: 0
+      }),
+      expect.any(Error)
+    );
+    const subscriberLog = consoleError.mock.calls[0]?.[1] as
+      | { readonly subscriberName?: unknown }
+      | undefined;
+    expect(typeof subscriberLog?.subscriberName).toBe("string");
+  });
+
   it("shows timestamp gap reject reasons in fusion snapshots", async () => {
     const frontTracker = createFakeTracker();
     const sideTracker = createFakeTracker();

--- a/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { telemetryJsonFilesToDelete } from "../../../../../src/features/diagnostic-workbench/recording/jsonRotation";
+
+describe("telemetryJsonFilesToDelete", () => {
+  it("keeps the newest N telemetry JSON files and deletes older names", () => {
+    const names = [
+      "telemetry-2026-04-19T08-30-13Z.json",
+      "front.webm",
+      "telemetry-2026-04-19T08-30-15Z.json",
+      "telemetry-2026-04-19T08-30-14Z.json",
+      "notes.json"
+    ];
+
+    expect(telemetryJsonFilesToDelete(names, 2)).toEqual([
+      "telemetry-2026-04-19T08-30-13Z.json"
+    ]);
+  });
+
+  it("returns an empty list when capacity covers all telemetry files", () => {
+    expect(
+      telemetryJsonFilesToDelete(
+        [
+          "telemetry-2026-04-19T08-30-13Z.json",
+          "telemetry-2026-04-19T08-30-14Z.json"
+        ],
+        10
+      )
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
@@ -27,4 +27,42 @@ describe("telemetryJsonFilesToDelete", () => {
       )
     ).toEqual([]);
   });
+
+  it("ignores user-created telemetry-looking JSON files", () => {
+    expect(
+      telemetryJsonFilesToDelete(
+        [
+          "telemetry-notes.json",
+          "telemetry-export.json",
+          "my-telemetry.json",
+          "telemetry-2026-04-19T08-30-15-432Z.json"
+        ],
+        0
+      )
+    ).toEqual(["telemetry-2026-04-19T08-30-15-432Z.json"]);
+  });
+
+  it("ignores timestamp names without millisecond precision", () => {
+    expect(
+      telemetryJsonFilesToDelete(
+        [
+          "telemetry-2026-04-19T08-30-15Z.json",
+          "telemetry-2026-04-19T08-30-15-432Z.json"
+        ],
+        0
+      )
+    ).toEqual(["telemetry-2026-04-19T08-30-15-432Z.json"]);
+  });
+
+  it("deletes only the oldest valid telemetry file from mixed entries", () => {
+    const validNames = Array.from(
+      { length: 10 },
+      (_, index) =>
+        `telemetry-2026-04-19T08-30-${String(index).padStart(2, "0")}-000Z.json`
+    );
+
+    expect(
+      telemetryJsonFilesToDelete([...validNames, "telemetry-notes.json"], 9)
+    ).toEqual(["telemetry-2026-04-19T08-30-00-000Z.json"]);
+  });
 });

--- a/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/jsonRotation.test.ts
@@ -4,15 +4,15 @@ import { telemetryJsonFilesToDelete } from "../../../../../src/features/diagnost
 describe("telemetryJsonFilesToDelete", () => {
   it("keeps the newest N telemetry JSON files and deletes older names", () => {
     const names = [
-      "telemetry-2026-04-19T08-30-13Z.json",
+      "telemetry-2026-04-19T08-30-13-123Z.json",
       "front.webm",
-      "telemetry-2026-04-19T08-30-15Z.json",
-      "telemetry-2026-04-19T08-30-14Z.json",
+      "telemetry-2026-04-19T08-30-15-123Z.json",
+      "telemetry-2026-04-19T08-30-14-123Z.json",
       "notes.json"
     ];
 
     expect(telemetryJsonFilesToDelete(names, 2)).toEqual([
-      "telemetry-2026-04-19T08-30-13Z.json"
+      "telemetry-2026-04-19T08-30-13-123Z.json"
     ]);
   });
 
@@ -20,8 +20,8 @@ describe("telemetryJsonFilesToDelete", () => {
     expect(
       telemetryJsonFilesToDelete(
         [
-          "telemetry-2026-04-19T08-30-13Z.json",
-          "telemetry-2026-04-19T08-30-14Z.json"
+          "telemetry-2026-04-19T08-30-13-123Z.json",
+          "telemetry-2026-04-19T08-30-14-123Z.json"
         ],
         10
       )

--- a/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createSessionRecorder,
   type DiagnosticFrameSubscription
@@ -94,6 +94,46 @@ const createFrame = (frameTimestampMs: number): TelemetryFrame => ({
 });
 
 describe("createSessionRecorder", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls showDirectoryPicker with the window receiver", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const windowLike = {
+      showDirectoryPicker: vi.fn(function (
+        this: unknown,
+        options: { readonly mode: "readwrite" }
+      ) {
+        if (this !== windowLike) {
+          throw new TypeError("Illegal invocation");
+        }
+
+        expect(options).toEqual({ mode: "readwrite" });
+        return Promise.resolve(
+          directory as unknown as FileSystemDirectoryHandle
+        );
+      })
+    };
+    vi.stubGlobal("window", windowLike);
+    const recorder = createSessionRecorder({
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn()
+      }))
+    });
+
+    await recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    });
+
+    expect(windowLike.showDirectoryPicker).toHaveBeenCalledOnce();
+    expect(recorder.getState().status).toBe("recording");
+  });
+
   it("records telemetry frames to JSON and starts front and side videos", async () => {
     const directory = new FakeFileSystemDirectoryHandle();
     let frameCallback: ((frame: TelemetryFrame) => void) | undefined;
@@ -124,7 +164,9 @@ describe("createSessionRecorder", () => {
     await recorder.stop();
     frameCallback?.(createFrame(200));
 
-    const jsonFile = directory.files.get("telemetry-2026-04-19T08-30-15Z.json");
+    const jsonFile = directory.files.get(
+      "telemetry-2026-04-19T08-30-15-000Z.json"
+    );
     if (jsonFile === undefined) {
       throw new Error("Telemetry JSON file was not written");
     }
@@ -153,7 +195,7 @@ describe("createSessionRecorder", () => {
 
     for (let index = 0; index < 11; index += 1) {
       await directory.getFileHandle(
-        `telemetry-2026-04-19T08-30-${String(index).padStart(2, "0")}Z.json`,
+        `telemetry-2026-04-19T08-30-${String(index).padStart(2, "0")}-000Z.json`,
         { create: true }
       );
     }
@@ -177,9 +219,82 @@ describe("createSessionRecorder", () => {
     await recorder.stop();
 
     expect(directory.deletedNames).toEqual([
-      "telemetry-2026-04-19T08-30-01Z.json",
-      "telemetry-2026-04-19T08-30-00Z.json"
+      "telemetry-2026-04-19T08-30-01-000Z.json",
+      "telemetry-2026-04-19T08-30-00-000Z.json"
     ]);
+  });
+
+  it("uses millisecond precision in telemetry file names", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const now = vi
+      .fn<() => Date>()
+      .mockReturnValueOnce(new Date("2026-04-19T08:30:15.123Z"))
+      .mockReturnValueOnce(new Date("2026-04-19T08:30:15.123Z"))
+      .mockReturnValueOnce(new Date("2026-04-19T08:30:15.456Z"))
+      .mockReturnValueOnce(new Date("2026-04-19T08:30:15.456Z"));
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now,
+      createVideoRecorder: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn()
+      }))
+    });
+    const startOptions = {
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    };
+
+    await recorder.start(startOptions);
+    await recorder.stop();
+    await recorder.start(startOptions);
+    await recorder.stop();
+
+    expect(directory.files.has("telemetry-2026-04-19T08-30-15-123Z.json")).toBe(
+      true
+    );
+    expect(directory.files.has("telemetry-2026-04-19T08-30-15-456Z.json")).toBe(
+      true
+    );
+  });
+
+  it("stops any video recorder that started when the paired recorder fails", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const startedRecorderStop = vi.fn(() => Promise.resolve());
+    const failedRecorderStop = vi.fn(() => Promise.resolve());
+    const createVideoRecorder = vi
+      .fn()
+      .mockReturnValueOnce({
+        start: vi.fn(() => Promise.resolve()),
+        stop: startedRecorderStop
+      })
+      .mockReturnValueOnce({
+        start: vi.fn(() => Promise.reject(new Error("side start failed"))),
+        stop: failedRecorderStop
+      });
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder
+    });
+
+    await recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    });
+
+    expect(startedRecorderStop).toHaveBeenCalledOnce();
+    expect(failedRecorderStop).not.toHaveBeenCalled();
+    expect(recorder.getState()).toEqual({
+      status: "error",
+      message: "side start failed"
+    });
   });
 
   it("prompts again when the reused directory permission is denied", async () => {

--- a/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSessionRecorder,
+  type DiagnosticFrameSubscription
+} from "../../../../../src/features/diagnostic-workbench/recording/sessionRecorder";
+import type { TelemetryFrame } from "../../../../../src/features/diagnostic-workbench/recording/telemetryFrame";
+import { defaultFrontAimCalibration } from "../../../../../src/features/front-aim";
+import { defaultSideTriggerCalibration } from "../../../../../src/features/side-trigger";
+import { FakeFileSystemDirectoryHandle } from "../../../../helpers/fileSystemAccessMocks";
+
+const timestamp = {
+  frameTimestampMs: 100,
+  timestampSource: "requestVideoFrameCallbackCaptureTime" as const,
+  presentedFrames: 1,
+  receivedAtPerformanceMs: 101
+};
+
+const createFrame = (frameTimestampMs: number): TelemetryFrame => ({
+  timestamp: { ...timestamp, frameTimestampMs },
+  fusionMode: "pairedFrontAndSide",
+  calibration: {
+    frontAim: defaultFrontAimCalibration,
+    sideTrigger: defaultSideTriggerCalibration
+  },
+  front: {
+    landmarks: {
+      wrist: { x: 0, y: 0, z: 0 },
+      thumbIp: { x: 0.1, y: 0, z: 0 },
+      thumbTip: { x: 0.2, y: 0, z: 0 },
+      indexMcp: { x: 0.3, y: 0, z: 0 },
+      indexTip: { x: 0.4, y: 0, z: 0 },
+      middleTip: { x: 0.5, y: 0, z: 0 },
+      ringTip: { x: 0.6, y: 0, z: 0 },
+      pinkyTip: { x: 0.7, y: 0, z: 0 }
+    },
+    laneHealth: "tracking",
+    aimContext: {
+      aimAvailability: "available",
+      aimSmoothingState: "tracking",
+      frontHandDetected: true,
+      frontTrackingConfidence: 0.9,
+      aimPointViewport: { x: 320, y: 240 },
+      aimPointNormalized: { x: 0.5, y: 0.5 },
+      sourceFrameSize: { width: 640, height: 480 },
+      calibrationStatus: "default",
+      calibration: defaultFrontAimCalibration,
+      lastLostReason: undefined
+    }
+  },
+  side: {
+    landmarks: undefined,
+    worldLandmarks: undefined,
+    sideViewQuality: "good",
+    evidence: {
+      sideHandDetected: true,
+      sideViewQuality: "good",
+      pullEvidenceScalar: 0.8,
+      releaseEvidenceScalar: 0.2,
+      triggerPostureConfidence: 0.9,
+      shotCandidateConfidence: 0.8,
+      rejectReason: undefined,
+      usedWorldLandmarks: true
+    },
+    fsmPhase: "SideTriggerPulledLatched",
+    triggerEdge: "shotCommitted",
+    laneHealth: "tracking"
+  },
+  fusion: {
+    fusionTimestampMs: frameTimestampMs,
+    fusionMode: "pairedFrontAndSide",
+    timeDeltaBetweenLanesMs: 4,
+    aim: undefined,
+    trigger: undefined,
+    shotFired: true,
+    inputConfidence: 0.8,
+    frontSource: {
+      laneRole: "frontAim",
+      frameTimestamp: { ...timestamp, frameTimestampMs },
+      frameAgeMs: 1,
+      laneHealth: "tracking",
+      availability: "available",
+      rejectReason: "none"
+    },
+    sideSource: {
+      laneRole: "sideTrigger",
+      frameTimestamp: { ...timestamp, frameTimestampMs: frameTimestampMs + 4 },
+      frameAgeMs: 0,
+      laneHealth: "tracking",
+      availability: "available",
+      rejectReason: "none"
+    },
+    fusionRejectReason: "none"
+  }
+});
+
+describe("createSessionRecorder", () => {
+  it("records telemetry frames to JSON and starts front and side videos", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    let frameCallback: ((frame: TelemetryFrame) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const startVideo = vi.fn();
+    const stopVideo = vi.fn();
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder: vi.fn(() => ({
+        start: startVideo,
+        stop: stopVideo
+      }))
+    });
+    const subscribeFrame: DiagnosticFrameSubscription = (callback) => {
+      frameCallback = callback;
+      return unsubscribe;
+    };
+
+    await recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame
+    });
+    frameCallback?.(createFrame(100));
+    await recorder.stop();
+    frameCallback?.(createFrame(200));
+
+    const jsonFile = directory.files.get("telemetry-2026-04-19T08-30-15Z.json");
+    if (jsonFile === undefined) {
+      throw new Error("Telemetry JSON file was not written");
+    }
+    const payload = JSON.parse(await jsonFile.text()) as {
+      schemaVersion: number;
+      sessionStart: string;
+      sessionEnd: string;
+      frames: TelemetryFrame[];
+    };
+
+    expect(startVideo).toHaveBeenCalledTimes(2);
+    expect(stopVideo).toHaveBeenCalledTimes(2);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(directory.files.has("front.webm")).toBe(true);
+    expect(directory.files.has("side.webm")).toBe(true);
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.sessionStart).toBe("2026-04-19T08:30:15.000Z");
+    expect(payload.sessionEnd).toBe("2026-04-19T08:30:15.000Z");
+    expect(payload.frames).toHaveLength(1);
+    expect(payload.frames[0]?.fusion.shotFired).toBe(true);
+    expect(payload.frames[0]?.side.triggerEdge).toBe("shotCommitted");
+  });
+
+  it("rotates telemetry JSON files to the newest ten after stop", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+
+    for (let index = 0; index < 11; index += 1) {
+      await directory.getFileHandle(
+        `telemetry-2026-04-19T08-30-${String(index).padStart(2, "0")}Z.json`,
+        { create: true }
+      );
+    }
+
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn()
+      }))
+    });
+
+    await recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    });
+    await recorder.stop();
+
+    expect(directory.deletedNames).toEqual([
+      "telemetry-2026-04-19T08-30-01Z.json",
+      "telemetry-2026-04-19T08-30-00Z.json"
+    ]);
+  });
+
+  it("prompts again when the reused directory permission is denied", async () => {
+    const firstDirectory = new FakeFileSystemDirectoryHandle("first");
+    const secondDirectory = new FakeFileSystemDirectoryHandle("second");
+    const requestDirectoryHandle = vi
+      .fn<() => Promise<FileSystemDirectoryHandle>>()
+      .mockResolvedValueOnce(
+        firstDirectory as unknown as FileSystemDirectoryHandle
+      )
+      .mockResolvedValueOnce(
+        secondDirectory as unknown as FileSystemDirectoryHandle
+      );
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle,
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn()
+      }))
+    });
+    const startOptions = {
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    };
+
+    await recorder.start(startOptions);
+    await recorder.stop();
+    firstDirectory.permissionState = "denied";
+    await recorder.start(startOptions);
+
+    expect(requestDirectoryHandle).toHaveBeenCalledTimes(2);
+    expect(secondDirectory.files.has("front.webm")).toBe(true);
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
@@ -232,15 +232,97 @@ describe("createSessionRecorder", () => {
     expect(recorder.getState().status).toBe("recording");
   });
 
-  it("rotates telemetry JSON files to the newest ten after stop", async () => {
+  it("retries recording after a directory picker error", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const requestDirectoryHandle = vi
+      .fn<() => Promise<FileSystemDirectoryHandle>>()
+      .mockRejectedValueOnce(new Error("picker cancelled"))
+      .mockResolvedValueOnce(
+        directory as unknown as FileSystemDirectoryHandle
+      );
+    const createVideoRecorder = vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn()
+    }));
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle,
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder
+    });
+    const startOptions = {
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    };
+
+    await recorder.start(startOptions);
+    expect(recorder.getState()).toEqual({
+      status: "error",
+      message: "picker cancelled"
+    });
+
+    const retry = recorder.start(startOptions);
+    expect(recorder.getState()).toEqual({ status: "starting" });
+    await retry;
+
+    expect(requestDirectoryHandle).toHaveBeenCalledTimes(2);
+    expect(createVideoRecorder).toHaveBeenCalledTimes(2);
+    expect(recorder.getState().status).toBe("recording");
+  });
+
+  it("isolates state listener exceptions from later listeners and callers", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle: vi.fn(() =>
+        Promise.resolve(directory as unknown as FileSystemDirectoryHandle)
+      ),
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn()
+      }))
+    });
+    const receivedStates: string[] = [];
+    recorder.subscribe(() => {
+      throw new Error("listener failed");
+    });
+    recorder.subscribe((state) => {
+      receivedStates.push(state.status);
+    });
+
+    try {
+      await expect(
+        recorder.start({
+          frontStream: { id: "front-stream" } as MediaStream,
+          sideStream: { id: "side-stream" } as MediaStream,
+          subscribeFrame: () => vi.fn()
+        })
+      ).resolves.toBeUndefined();
+
+      expect(receivedStates).toContain("starting");
+      expect(receivedStates).toContain("recording");
+      expect(consoleError).toHaveBeenCalledWith(
+        "[diagnostic recording] state listener threw",
+        expect.any(Error)
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("rotates only app telemetry JSON files to the newest ten after stop", async () => {
     const directory = new FakeFileSystemDirectoryHandle();
 
-    for (let index = 0; index < 11; index += 1) {
+    for (let index = 0; index < 10; index += 1) {
       await directory.getFileHandle(
         `telemetry-2026-04-19T08-30-${String(index).padStart(2, "0")}-000Z.json`,
         { create: true }
       );
     }
+    await directory.getFileHandle("telemetry-notes.json", { create: true });
 
     const recorder = createSessionRecorder({
       requestDirectoryHandle: vi.fn(() =>
@@ -261,9 +343,9 @@ describe("createSessionRecorder", () => {
     await recorder.stop();
 
     expect(directory.deletedNames).toEqual([
-      "telemetry-2026-04-19T08-30-01-000Z.json",
       "telemetry-2026-04-19T08-30-00-000Z.json"
     ]);
+    expect(directory.files.has("telemetry-notes.json")).toBe(true);
   });
 
   it("uses millisecond precision in telemetry file names", async () => {

--- a/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
@@ -93,6 +93,17 @@ const createFrame = (frameTimestampMs: number): TelemetryFrame => ({
   }
 });
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
 describe("createSessionRecorder", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -188,6 +199,37 @@ describe("createSessionRecorder", () => {
     expect(payload.frames).toHaveLength(1);
     expect(payload.frames[0]?.fusion.shotFired).toBe(true);
     expect(payload.frames[0]?.side.triggerEdge).toBe("shotCommitted");
+  });
+
+  it("serializes rapid start calls while the directory picker is pending", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const directoryPicker = createDeferred<FileSystemDirectoryHandle>();
+    const requestDirectoryHandle = vi.fn(() => directoryPicker.promise);
+    const createVideoRecorder = vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn()
+    }));
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle,
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder
+    });
+    const startOptions = {
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    };
+
+    const firstStart = recorder.start(startOptions);
+    const secondStart = recorder.start(startOptions);
+
+    expect(recorder.getState()).toEqual({ status: "starting" });
+    expect(requestDirectoryHandle).toHaveBeenCalledOnce();
+    directoryPicker.resolve(directory as unknown as FileSystemDirectoryHandle);
+    await Promise.all([firstStart, secondStart]);
+
+    expect(createVideoRecorder).toHaveBeenCalledTimes(2);
+    expect(recorder.getState().status).toBe("recording");
   });
 
   it("rotates telemetry JSON files to the newest ten after stop", async () => {

--- a/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/sessionRecorder.test.ts
@@ -232,6 +232,38 @@ describe("createSessionRecorder", () => {
     expect(recorder.getState().status).toBe("recording");
   });
 
+  it("cancels a pending start when stop is called during directory selection", async () => {
+    const directory = new FakeFileSystemDirectoryHandle();
+    const directoryPicker = createDeferred<FileSystemDirectoryHandle>();
+    const requestDirectoryHandle = vi.fn(() => directoryPicker.promise);
+    const createVideoRecorder = vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn()
+    }));
+    const recorder = createSessionRecorder({
+      requestDirectoryHandle,
+      now: () => new Date("2026-04-19T08:30:15.000Z"),
+      createVideoRecorder
+    });
+
+    const startPromise = recorder.start({
+      frontStream: { id: "front-stream" } as MediaStream,
+      sideStream: { id: "side-stream" } as MediaStream,
+      subscribeFrame: () => vi.fn()
+    });
+
+    expect(recorder.getState()).toEqual({ status: "starting" });
+    await recorder.stop();
+    expect(recorder.getState()).toEqual({ status: "idle" });
+
+    directoryPicker.resolve(directory as unknown as FileSystemDirectoryHandle);
+    await startPromise;
+
+    expect(createVideoRecorder).not.toHaveBeenCalled();
+    expect(directory.files.size).toBe(0);
+    expect(recorder.getState()).toEqual({ status: "idle" });
+  });
+
   it("retries recording after a directory picker error", async () => {
     const directory = new FakeFileSystemDirectoryHandle();
     const requestDirectoryHandle = vi

--- a/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStreamRecorder } from "../../../../../src/features/diagnostic-workbench/recording/streamRecorder";
+import { FakeFileSystemFileHandle } from "../../../../helpers/fileSystemAccessMocks";
+
+class FakeMediaRecorder {
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  state: RecordingState = "inactive";
+  readonly stream: MediaStream;
+
+  constructor(stream: MediaStream) {
+    this.stream = stream;
+  }
+
+  start(): void {
+    this.state = "recording";
+  }
+
+  stop(): void {
+    this.state = "inactive";
+  }
+
+  emitBlob(blob: Blob): void {
+    this.ondataavailable?.({ data: blob } as BlobEvent);
+  }
+}
+
+describe("createStreamRecorder", () => {
+  it("writes blob chunks to the file handle and closes on stop", async () => {
+    const recorderInstances: FakeMediaRecorder[] = [];
+    const fileHandle = new FakeFileSystemFileHandle("front.webm");
+    const stream = { id: "front-stream" } as MediaStream;
+    const recorder = createStreamRecorder({
+      stream,
+      fileHandle: fileHandle as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: (input) => {
+        const fake = new FakeMediaRecorder(input);
+        recorderInstances.push(fake);
+        return fake as unknown as MediaRecorder;
+      }
+    });
+
+    await recorder.start();
+    const chunk = new Blob(["video"]);
+    recorderInstances[0]?.emitBlob(chunk);
+    await recorder.stop();
+
+    expect(fileHandle.writable.writes).toEqual([chunk]);
+    expect(fileHandle.writable.closed).toBe(true);
+  });
+
+  it("discards chunks that arrive after stop closes the writable stream", async () => {
+    const recorderInstances: FakeMediaRecorder[] = [];
+    const fileHandle = new FakeFileSystemFileHandle("side.webm");
+    const recorder = createStreamRecorder({
+      stream: { id: "side-stream" } as MediaStream,
+      fileHandle: fileHandle as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: (input) => {
+        const fake = new FakeMediaRecorder(input);
+        recorderInstances.push(fake);
+        return fake as unknown as MediaRecorder;
+      }
+    });
+
+    await recorder.start();
+    await recorder.stop();
+    recorderInstances[0]?.emitBlob(new Blob(["late"]));
+
+    expect(fileHandle.writable.writes).toEqual([]);
+    expect(fileHandle.writable.closed).toBe(true);
+  });
+
+  it("does not request a MediaRecorder mime type when none is supported", async () => {
+    const factory = vi.fn(
+      (stream: MediaStream) =>
+        new FakeMediaRecorder(stream) as unknown as MediaRecorder
+    );
+    const recorder = createStreamRecorder({
+      stream: { id: "plain-stream" } as MediaStream,
+      fileHandle: new FakeFileSystemFileHandle(
+        "plain.webm"
+      ) as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: factory,
+      isTypeSupported: () => false
+    });
+
+    await recorder.start();
+
+    expect(factory).toHaveBeenCalledWith({ id: "plain-stream" }, undefined);
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
@@ -4,8 +4,10 @@ import { FakeFileSystemFileHandle } from "../../../../helpers/fileSystemAccessMo
 
 class FakeMediaRecorder {
   ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
   state: RecordingState = "inactive";
   readonly stream: MediaStream;
+  private queuedStopBlob: Blob | undefined;
 
   constructor(stream: MediaStream) {
     this.stream = stream;
@@ -17,10 +19,19 @@ class FakeMediaRecorder {
 
   stop(): void {
     this.state = "inactive";
+    if (this.queuedStopBlob !== undefined) {
+      this.emitBlob(this.queuedStopBlob);
+      this.queuedStopBlob = undefined;
+    }
+    this.onstop?.();
   }
 
   emitBlob(blob: Blob): void {
     this.ondataavailable?.({ data: blob } as BlobEvent);
+  }
+
+  queueStopBlob(blob: Blob): void {
+    this.queuedStopBlob = blob;
   }
 }
 
@@ -44,8 +55,31 @@ describe("createStreamRecorder", () => {
     recorderInstances[0]?.emitBlob(chunk);
     await recorder.stop();
 
-    expect(fileHandle.writable.writes).toEqual([chunk]);
-    expect(fileHandle.writable.closed).toBe(true);
+    expect(fileHandle.latestWritable?.writes).toEqual([chunk]);
+    expect(fileHandle.latestWritable?.closed).toBe(true);
+  });
+
+  it("preserves the final MediaRecorder chunk emitted during stop", async () => {
+    const recorderInstances: FakeMediaRecorder[] = [];
+    const fileHandle = new FakeFileSystemFileHandle("front.webm");
+    const stream = { id: "front-stream" } as MediaStream;
+    const recorder = createStreamRecorder({
+      stream,
+      fileHandle: fileHandle as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: (input) => {
+        const fake = new FakeMediaRecorder(input);
+        recorderInstances.push(fake);
+        return fake as unknown as MediaRecorder;
+      }
+    });
+
+    await recorder.start();
+    const finalChunk = new Blob(["final-video"]);
+    recorderInstances[0]?.queueStopBlob(finalChunk);
+    await recorder.stop();
+
+    expect(fileHandle.latestWritable?.writes).toEqual([finalChunk]);
+    expect(fileHandle.latestWritable?.closed).toBe(true);
   });
 
   it("discards chunks that arrive after stop closes the writable stream", async () => {
@@ -65,8 +99,30 @@ describe("createStreamRecorder", () => {
     await recorder.stop();
     recorderInstances[0]?.emitBlob(new Blob(["late"]));
 
-    expect(fileHandle.writable.writes).toEqual([]);
-    expect(fileHandle.writable.closed).toBe(true);
+    expect(fileHandle.latestWritable?.writes).toEqual([]);
+    expect(fileHandle.latestWritable?.closed).toBe(true);
+  });
+
+  it("closes the writable stream when MediaRecorder start fails", async () => {
+    const fileHandle = new FakeFileSystemFileHandle("failed.webm");
+    const recorder = createStreamRecorder({
+      stream: { id: "failed-stream" } as MediaStream,
+      fileHandle: fileHandle as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: (input) => {
+        const fake = new FakeMediaRecorder(input);
+        fake.start = () => {
+          throw new Error("MediaRecorder start failed");
+        };
+        return fake as unknown as MediaRecorder;
+      }
+    });
+
+    await expect(recorder.start()).rejects.toThrow(
+      "MediaRecorder start failed"
+    );
+
+    expect(fileHandle.writableStreams).toHaveLength(1);
+    expect(fileHandle.latestWritable?.closed).toBe(true);
   });
 
   it("does not request a MediaRecorder mime type when none is supported", async () => {

--- a/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
+++ b/tests/unit/features/diagnostic-workbench/recording/streamRecorder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamRecorder } from "../../../../../src/features/diagnostic-workbench/recording/streamRecorder";
 import { FakeFileSystemFileHandle } from "../../../../helpers/fileSystemAccessMocks";
 
@@ -7,18 +7,30 @@ class FakeMediaRecorder {
   onstop: (() => void) | null = null;
   state: RecordingState = "inactive";
   readonly stream: MediaStream;
+  readonly startTimeslices: number[] = [];
+  private intervalId: ReturnType<typeof setInterval> | undefined;
   private queuedStopBlob: Blob | undefined;
 
   constructor(stream: MediaStream) {
     this.stream = stream;
   }
 
-  start(): void {
+  start(timeslice?: number): void {
     this.state = "recording";
+    if (timeslice !== undefined) {
+      this.startTimeslices.push(timeslice);
+      this.intervalId = setInterval(() => {
+        this.emitBlob(new Blob(["periodic-video"]));
+      }, timeslice);
+    }
   }
 
   stop(): void {
     this.state = "inactive";
+    if (this.intervalId !== undefined) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
     if (this.queuedStopBlob !== undefined) {
       this.emitBlob(this.queuedStopBlob);
       this.queuedStopBlob = undefined;
@@ -36,6 +48,10 @@ class FakeMediaRecorder {
 }
 
 describe("createStreamRecorder", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("writes blob chunks to the file handle and closes on stop", async () => {
     const recorderInstances: FakeMediaRecorder[] = [];
     const fileHandle = new FakeFileSystemFileHandle("front.webm");
@@ -80,6 +96,29 @@ describe("createStreamRecorder", () => {
 
     expect(fileHandle.latestWritable?.writes).toEqual([finalChunk]);
     expect(fileHandle.latestWritable?.closed).toBe(true);
+  });
+
+  it("streams periodic chunks to the writable before stop", async () => {
+    vi.useFakeTimers();
+    const recorderInstances: FakeMediaRecorder[] = [];
+    const fileHandle = new FakeFileSystemFileHandle("front.webm");
+    const recorder = createStreamRecorder({
+      stream: { id: "front-stream" } as MediaStream,
+      fileHandle: fileHandle as unknown as FileSystemFileHandle,
+      mediaRecorderFactory: (input) => {
+        const fake = new FakeMediaRecorder(input);
+        recorderInstances.push(fake);
+        return fake as unknown as MediaRecorder;
+      }
+    });
+
+    await recorder.start();
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(recorderInstances[0]?.startTimeslices).toEqual([1000]);
+    expect(fileHandle.latestWritable?.writes.length).toBeGreaterThanOrEqual(3);
+
+    await recorder.stop();
   });
 
   it("discards chunks that arrive after stop closes the writable stream", async () => {

--- a/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { renderRecordingControls } from "../../../../src/features/diagnostic-workbench/renderRecordingControls";
+
+describe("renderRecordingControls", () => {
+  it("renders the idle Record button and status", () => {
+    const html = renderRecordingControls({ status: "idle" });
+
+    expect(html).toContain("Recording");
+    expect(html).toContain('data-wb-action="startRecording"');
+    expect(html).toMatch(/<span>Status<\/span>\s*<strong>idle<\/strong>/);
+  });
+
+  it("renders the Stop button and elapsed timer while recording", () => {
+    const html = renderRecordingControls({
+      status: "recording",
+      elapsedMs: 65_000
+    });
+
+    expect(html).toContain('data-wb-action="stopRecording"');
+    expect(html).toMatch(/<span>Timer<\/span>\s*<strong>01:05<\/strong>/);
+    expect(html).toMatch(/<span>Status<\/span>\s*<strong>recording<\/strong>/);
+  });
+
+  it("escapes error text from file or directory names", () => {
+    const html = renderRecordingControls({
+      status: "error",
+      message: "Cannot write telemetry-<bad>.json"
+    });
+
+    expect(html).toContain("telemetry-&lt;bad&gt;.json");
+    expect(html).not.toContain("telemetry-<bad>.json");
+  });
+});

--- a/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
@@ -17,8 +17,19 @@ describe("renderRecordingControls", () => {
     });
 
     expect(html).toContain('data-wb-action="stopRecording"');
-    expect(html).toMatch(/<span>Timer<\/span>\s*<strong>01:05<\/strong>/);
+    expect(html).toMatch(
+      /<span>Timer<\/span>\s*<strong[^>]*data-recording-timer[^>]*>01:05<\/strong>/
+    );
     expect(html).toMatch(/<span>Status<\/span>\s*<strong>recording<\/strong>/);
+  });
+
+  it("renders disabled Preparing controls while capture startup is pending", () => {
+    const html = renderRecordingControls({ status: "starting" });
+
+    expect(html).toContain("<button");
+    expect(html).toContain("disabled");
+    expect(html).toContain("Preparing");
+    expect(html).toMatch(/<span>Status<\/span>\s*<strong>starting<\/strong>/);
   });
 
   it("renders disabled Saving controls while capture is being flushed", () => {

--- a/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderRecordingControls.test.ts
@@ -21,6 +21,15 @@ describe("renderRecordingControls", () => {
     expect(html).toMatch(/<span>Status<\/span>\s*<strong>recording<\/strong>/);
   });
 
+  it("renders disabled Saving controls while capture is being flushed", () => {
+    const html = renderRecordingControls({ status: "saving" });
+
+    expect(html).toContain("<button");
+    expect(html).toContain("disabled");
+    expect(html).toContain("Saving");
+    expect(html).toMatch(/<span>Status<\/span>\s*<strong>saving<\/strong>/);
+  });
+
   it("escapes error text from file or directory names", () => {
     const html = renderRecordingControls({
       status: "error",

--- a/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
+++ b/tests/unit/features/diagnostic-workbench/renderWorkbench.test.ts
@@ -264,6 +264,8 @@ describe("renderWorkbenchHTML", () => {
       {
         frontDetection: undefined,
         sideDetection: undefined,
+        frontFrameTimestamp: undefined,
+        sideFrameTimestamp: undefined,
         frontLaneHealth: "captureLost",
         sideLaneHealth: "tracking",
         frontAimFrame: undefined,
@@ -303,6 +305,8 @@ describe("renderWorkbenchHTML", () => {
       {
         frontDetection: createFrontDetection(),
         sideDetection: createSideDetection(),
+        frontFrameTimestamp: undefined,
+        sideFrameTimestamp: undefined,
         frontLaneHealth: "tracking",
         sideLaneHealth: "tracking",
         frontAimFrame: createAimFrame(),


### PR DESCRIPTION
## What

Adds diagnostic workbench recording for calibration iteration. A recording session captures per-frame telemetry JSON plus simultaneous front and side WebM video streams.

## File layout

- `front.webm` and `side.webm` are overwritten for each session in the picked directory.
- `telemetry-{ISO_TIMESTAMP_DASHED}.json` is written on Stop.
- Telemetry JSON rotation keeps the newest 10 `telemetry-*.json` files and deletes older entries.

## How to use

1. Open `diagnostic.html` and enter live preview.
2. Click `Record`.
3. Pick a writable local directory when prompted.
4. Click `Stop` to flush videos and telemetry JSON.

## Notes

- Directory handles are reused only for the current workbench session; no localStorage or IndexedDB persistence is added.
- Telemetry follows the live diagnostic lane subscription. Video follows the MediaStreams active when recording starts; recording is stopped when preview streams are torn down or reconfigured.
- Out of scope: no replay UI yet, no calibration auto-tuner, and no recording reader.

## Verification

- `npm run check`
- `npm run test:e2e`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/balloonshoot_v2/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New features**
  * Added session recording to the diagnostic workbench. Provides simultaneous capture of front / side video and diagnostic telemetry, a subscription API, and recording lifecycle management.

* **UI improvements**
  * Added start / stop buttons, elapsed-time display, and error display to the recording panel. Applied responsive styling.

* **Documentation**
  * Added a recording-output operation guide.

* **Tests**
  * Added and expanded numerous unit / integration / E2E tests for the recording flow.

* **Chores**
  * Added the recording output directory to `.gitignore`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
