### PR TITLE
fix(input-fusion): fire side shot commit when pair fails on timestamp gap

### DIFF
--- a/docs/superpowers/plans/2026-04-18-m7-implementation-decomposition.md
+++ b/docs/superpowers/plans/2026-04-18-m7-implementation-decomposition.md
@@ -174,12 +174,12 @@ M7 開始前の post-M6 `main` で必ず確認する。
 - Output should be a small shape:
   - crosshair point when `aim` is available or estimated
   - no crosshair when `aim` unavailable
-  - `shot` action only when `fusionMode === "pairedFrontAndSide"` and `shotFired === true`
+  - `shot` action when `shotFired === true` and a crosshair is present (superseded 2026-04-25: relaxed from the original `fusionMode === "pairedFrontAndSide"` gate so a side commit can fire when both lanes are individually usable but the pair fails on `timestampGapTooLarge`)
   - degraded status for production copy, not telemetry
 - Add M7-level shot consumption guard because the runtime may render the same latest fused frame across multiple rAF ticks.
 - Key consumed shots from M6 side source summary if available. If M6 does not expose a stable key, build one from `fusionTimestampMs`, `sideSource.frameTimestampMs`, `sideSource.presentedFrames`, and trigger edge summary. Do not inspect `TriggerInputFrame` directly.
-- `frontOnlyAim` can move crosshair but cannot score.
-- `sideOnlyTriggerDiagnostic` cannot fire and must not consume a shot.
+- `frontOnlyAim` can move the crosshair, and can score only when the side lane is also individually usable in the same frame (superseded 2026-04-25).
+- `sideOnlyTriggerDiagnostic` cannot fire and must not consume a shot (front lane unusable → shot edge stays unconsumed for retry once front recovers).
 
 **Test plan:**
 - Unit tests:

--- a/src/features/gameplay/domain/fusedGameInput.ts
+++ b/src/features/gameplay/domain/fusedGameInput.ts
@@ -61,11 +61,7 @@ export const readFusedGameInput = (
       ? { kind: "inputPreparing" as const, reason: frame.fusionRejectReason }
       : undefined;
 
-  if (
-    frame.fusionMode !== "pairedFrontAndSide" ||
-    !frame.shotFired ||
-    crosshair === undefined
-  ) {
+  if (!frame.shotFired || crosshair === undefined) {
     return { crosshair, shot: undefined, status };
   }
 

--- a/src/features/input-fusion/createInputFusionMapper.ts
+++ b/src/features/input-fusion/createInputFusionMapper.ts
@@ -294,7 +294,7 @@ export const createInputFusionMapper = (): InputFusionMapper => {
     const sideUsable = isSideUsable(sideFrame, fusionTimestampMs, context);
     const fusionMode = fusionModeFor(pair, frontUsable, sideUsable);
     const shotFired =
-      fusionMode === "pairedFrontAndSide" && sideFrame !== undefined
+      sideUsable && frontUsable && sideFrame !== undefined
         ? shotConsumption.consumeIfShotCommit(sideFrame)
         : false;
     const fusedFrame: FusedGameInputFrame = {

--- a/src/features/input-fusion/createInputFusionMapper.ts
+++ b/src/features/input-fusion/createInputFusionMapper.ts
@@ -190,7 +190,7 @@ const isSideUsable = (
   frame: TriggerInputFrame | undefined,
   fusionTimestampMs: number,
   context: InputFusionMapperContext
-): boolean =>
+): frame is TriggerInputFrame =>
   frame !== undefined &&
   frame.triggerAvailability !== "unavailable" &&
   !isFailed(context.sideLaneHealth) &&
@@ -294,7 +294,7 @@ export const createInputFusionMapper = (): InputFusionMapper => {
     const sideUsable = isSideUsable(sideFrame, fusionTimestampMs, context);
     const fusionMode = fusionModeFor(pair, frontUsable, sideUsable);
     const shotFired =
-      sideUsable && frontUsable && sideFrame !== undefined
+      sideUsable && frontUsable
         ? shotConsumption.consumeIfShotCommit(sideFrame)
         : false;
     const fusedFrame: FusedGameInputFrame = {

--- a/tests/unit/features/gameplay/fusedGameInput.test.ts
+++ b/tests/unit/features/gameplay/fusedGameInput.test.ts
@@ -54,7 +54,7 @@ describe("fusedGameInput", () => {
     expect(readFusedGameInput(adapter, frame).shot).toBeUndefined();
   });
 
-  it("allows front-only aim movement but never fires", () => {
+  it("fires from frontOnlyAim mode when shotFired and aim available", () => {
     const adapter = createFusedGameInputAdapter();
     const result = readFusedGameInput(
       adapter,
@@ -66,7 +66,7 @@ describe("fusedGameInput", () => {
     );
 
     expect(result.crosshair).toEqual({ x: 320, y: 180 });
-    expect(result.shot).toBeUndefined();
+    expect(result.shot).toEqual({ x: 320, y: 180 });
   });
 
   it("ignores side-only trigger diagnostic frames for gameplay shots", () => {

--- a/tests/unit/features/input-fusion/createInputFusionMapper.test.ts
+++ b/tests/unit/features/input-fusion/createInputFusionMapper.test.ts
@@ -151,7 +151,31 @@ describe("createInputFusionMapper", () => {
     ).toBe("laneFailed");
   });
 
-  it("fires and consumes a shot commit only in paired mode", () => {
+  it("fires the side shot commit even when the pair fails due to timestamp gap", () => {
+    const mapper = createInputFusionMapper();
+    const gapContext = {
+      ...context,
+      tuning: {
+        ...context.tuning,
+        maxPairDeltaMs: 25,
+        maxFrameAgeMs: 250,
+        recentFrameRetentionWindowMs: 300
+      }
+    };
+
+    mapper.updateAimFrame(createAimFrame(100), gapContext);
+    const result = mapper.updateTriggerFrame(
+      createTriggerFrame(160, { triggerEdge: "shotCommitted" }),
+      gapContext
+    );
+
+    expect(result.fusedFrame.fusionMode).toBe("frontOnlyAim");
+    expect(result.fusedFrame.fusionRejectReason).toBe("timestampGapTooLarge");
+    expect(result.fusedFrame.shotFired).toBe(true);
+    expect(result.telemetry.shotEdgeConsumed).toBe(true);
+  });
+
+  it("fires and consumes a shot commit only when both lanes are usable", () => {
     const mapper = createInputFusionMapper();
     const sideCommit = createTriggerFrame(100, {
       triggerEdge: "shotCommitted"


### PR DESCRIPTION
## Summary

ユーザの「サイドカメラを優先したい」直感に沿った最小修正。trigger evidence は r9 で既に side-only だが、ゲーム発射の最終ゲートが \`fusionMode === pairedFrontAndSide\` を要求していたため、両 lane が個別に usable でも \`timestampGapTooLarge\` で pair が失敗するケースで side の \`shotCommitted\` が落ちていた。

## Root cause (Codex advisor + telemetry 再生で確定)

\`iterations/telemetry-2026-04-24T13-46-25-266Z.json\` 上の例:

- \`152136.3ms\`: side \`shotCommitted\` だが \`fusionMode=frontOnlyAim, fusionRejectReason=timestampGapTooLarge\` → \`shotFired=false\`
- \`185763.8ms\`: side \`shotCommitted, pullEvidenceScalar=1\` だが \`frontStale\` → \`shotFired=false\`

trigger 判定は side のみだが、commit が paired-only で gate されているねじれ。

## Changes

- \`createInputFusionMapper.ts:296-298\`: \`shotFired\` の consume ゲートを \`fusionMode === pairedFrontAndSide\` から \`sideUsable && frontUsable\` の AND に変更。両 lane が個別に usable なら pair 失敗でも fire。side-only / front 不可区間では従来通り消費しない (front 復帰時の retry を維持)。
- \`fusedGameInput.ts:64-69\`: gameplay 側のショット判定から \`pairedFrontAndSide\` 必須要件を撤去。\`shotFired && crosshair\` で commit。
- \`docs/superpowers/plans/2026-04-18-m7-implementation-decomposition.md\`: 関連箇所に supersession 注記を追加。
- 追加テスト: timestampGapTooLarge ケースで fire することを 1 件、frontOnlyAim mode + shotFired + aim 利用可で fire することを 1 件。

## Codex review history

- v1 (\`fusionMode === pairedFrontAndSide\` を完全撤去): P1 issue 2 件 — side-only 区間で edge を消費して回復後に lost、plan ドキュメント矛盾。
- v2 (本 PR、両 lane usable AND ゲート): P1 解消、残 P2 1 件 (下記 deferred)。

## Deferred (out of scope)

\`[P2]\` Buffered shot commit recovery: side が commit した直後に commit でない side frame が来て、それから front 復帰するシナリオでは、pair selection が新しい side frame を取りに行くため古い未消費の commit が retry されない。これは本 PR 前後で挙動同一の pre-existing limitation で、shot-edge buffer の scan-and-retry ロジックを追加する別 PR の話。

## Checks

- [x] unit tests: 521/521 pass (+1 regression for timestamp-gap fire path)
- [x] replay tests: 8/8 pass
- [x] typecheck / lint / knip: clean

## Falsifiable empirical test (Codex 推奨)

診断画面で 10 秒記録し、\`side.triggerEdge=shotCommitted\` の回数と \`game.shotFired=true\` の回数を比較。
- 修正前: \`timestampGapTooLarge\` / \`frontStale\` 区間で前者 > 後者
- 修正後: crosshair 表示中は両者 1:1 に近づく (frontStale 区間は依然 0、これは別 PR の P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/balloonshoot_v2/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ショット入力の登録ロジックを改善しました。フュージョンモードに関わらず、ショット発火時かつクロスヘアが利用可能な場合に正しくショットが消費されるようになりました。

* **テスト**
  * ショット登録の動作確認テストを更新し、様々なモード組み合わせでの正常な挙動を検証するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->